### PR TITLE
Migrations

### DIFF
--- a/contracts/covenant/src/msg.rs
+++ b/contracts/covenant/src/msg.rs
@@ -1,10 +1,10 @@
-use cosmwasm_schema::{QueryResponses, cw_serde};
+use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
-use covenant_ls::msg::InstantiateMsg as LsInstantiateMsg;
-use covenant_depositor::msg::InstantiateMsg as DepositorInstantiateMsg;
-use covenant_lp::msg::InstantiateMsg as LpInstantiateMsg;
 use covenant_clock::msg::InstantiateMsg as ClockInstantiateMsg;
+use covenant_depositor::msg::InstantiateMsg as DepositorInstantiateMsg;
 use covenant_holder::msg::InstantiateMsg as HolderInstantiateMsg;
+use covenant_lp::msg::InstantiateMsg as LpInstantiateMsg;
+use covenant_ls::msg::InstantiateMsg as LsInstantiateMsg;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -39,4 +39,12 @@ pub enum QueryMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
+pub enum MigrateMsg {
+    UpdateConfig {
+        clock: Option<covenant_clock::msg::MigrateMsg>,
+        depositer: Option<covenant_depositor::msg::MigrateMsg>,
+        lp: Option<covenant_lp::msg::MigrateMsg>,
+        ls: Option<covenant_ls::msg::MigrateMsg>,
+        holder: Option<covenant_holder::msg::MigrateMsg>,
+    },
+}

--- a/contracts/depositor/src/msg.rs
+++ b/contracts/depositor/src/msg.rs
@@ -53,4 +53,14 @@ pub enum QueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct MigrateMsg {}
+pub enum MigrateMsg {
+    UpdateConfig {
+        clock_addr: Option<String>,
+        st_atom_receiver: Option<WeightedReceiver>,
+        atom_receiver: Option<WeightedReceiver>,
+        gaia_neutron_ibc_transfer_channel_id: Option<String>,
+        neutron_gaia_connection_id: Option<String>,
+        gaia_stride_ibc_transfer_channel_id: Option<String>,
+        ls_address: Option<String>,
+    },
+}

--- a/contracts/holder/src/msg.rs
+++ b/contracts/holder/src/msg.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::Coin;
 
 #[cw_serde]
 pub struct InstantiateMsg {
-    /// A withdrawer is the only authorized address that can withdraw 
+    /// A withdrawer is the only authorized address that can withdraw
     /// from the contract. Anyone can instantiate the contract.
     pub withdrawer: Option<String>,
 }
@@ -11,7 +11,7 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     /// The withdraw message can only be called by the withdrawer
-    /// The withdraw can specify a quanity to be withdrawn. If no 
+    /// The withdraw can specify a quanity to be withdrawn. If no
     /// quantity is specified, the full balance is withdrawn
     Withdraw {
         quantity: Option<Vec<Coin>>,
@@ -22,4 +22,9 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     // Queries the withdrawer address
     Withdrawer {},
+}
+
+#[cw_serde]
+pub enum MigrateMsg {
+    UpdateWithdrawer { withdrawer: String},
 }

--- a/contracts/lper/src/msg.rs
+++ b/contracts/lper/src/msg.rs
@@ -31,5 +31,10 @@ pub enum QueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct MigrateMsg {
+pub enum MigrateMsg {
+  UpdateConfig {
+    clock_addr: Option<String>,
+    lp_position: Option<LPInfo>,
+    holder_address: Option<String>,
+  }
 }

--- a/contracts/ls/src/contract.rs
+++ b/contracts/ls/src/contract.rs
@@ -245,9 +245,7 @@ pub fn query(deps: Deps<NeutronQuery>, env: Env, msg: QueryMsg) -> NeutronResult
             interchain_account_id,
             connection_id,
         } => query_interchain_address(deps, env, interchain_account_id, connection_id),
-        QueryMsg::StrideICA {} => Ok(
-            to_binary(&ICA_ADDRESS.may_load(deps.storage)?)?
-        )
+        QueryMsg::StrideICA {} => Ok(to_binary(&ICA_ADDRESS.may_load(deps.storage)?)?),
     }
 }
 
@@ -342,9 +340,44 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> StdResult<Response> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
     deps.api.debug("WASMDEBUG: migrate");
-    Ok(Response::default())
+
+    match msg {
+        MigrateMsg::UpdateConfig {
+            clock_addr,
+            stride_neutron_ibc_transfer_channel_id,
+            lp_address,
+            neutron_stride_ibc_connection_id,
+            ls_denom,
+        } => {
+            if let Some(clock_addr) = clock_addr {
+                CLOCK_ADDRESS.save(deps.storage, &deps.api.addr_validate(&clock_addr)?)?;
+            }
+
+            if let Some(stride_neutron_ibc_transfer_channel_id) =
+                stride_neutron_ibc_transfer_channel_id
+            {
+                STRIDE_NEUTRON_IBC_TRANSFER_CHANNEL_ID
+                    .save(deps.storage, &stride_neutron_ibc_transfer_channel_id)?;
+            }
+
+            if let Some(lp_address) = lp_address {
+                LP_ADDRESS.save(deps.storage, &lp_address)?;
+            }
+
+            if let Some(neutron_stride_ibc_connection_id) = neutron_stride_ibc_connection_id {
+                NEUTRON_STRIDE_IBC_CONNECTION_ID
+                    .save(deps.storage, &neutron_stride_ibc_connection_id)?;
+            }
+
+            if let Some(ls_denom) = ls_denom {
+                LS_DENOM.save(deps.storage, &ls_denom)?;
+            }
+
+            Ok(Response::default())
+        }
+    }
 }
 
 // handler

--- a/contracts/ls/src/msg.rs
+++ b/contracts/ls/src/msg.rs
@@ -34,4 +34,12 @@ pub enum QueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct MigrateMsg {}
+pub enum MigrateMsg {
+  UpdateConfig {
+    clock_addr: Option<String>,
+    stride_neutron_ibc_transfer_channel_id: Option<String>,
+    lp_address: Option<String>,
+    neutron_stride_ibc_connection_id: Option<String>,
+    ls_denom: Option<String>,
+  }
+}


### PR DESCRIPTION
Added migrations to all contracts.
All of them can be called optionally from the covenant contract, which should be the admin of all other contracts.

Everything is optional, so you can send msg to covenant to only pause clock:
```json
{"update_config" : {
    "clock" : { "pause" : {} }
}}
```

Update withdrawer on holder contract:
```json
{"update_config" : {
    "holder" : { "update_withdrawer" : { "withdrawer": "some_withdrawer" } }
}}
```

Or both at the same time:
```json
{"update_config" : {
    "clock" : { "pause" : {} },
    "holder" : { "update_withdrawer" : { "withdrawer": "some_withdrawer" } }
}}
```