### PR TITLE
validating single sided liquidity ratio

### DIFF
--- a/contracts/covenant/src/suite_test/suite.rs
+++ b/contracts/covenant/src/suite_test/suite.rs
@@ -84,6 +84,7 @@ impl Default for SuiteBuilder {
                     lp_code: 1,
                     lp_position: TODO.to_string(),
                     label: "covenant_lp_contract".to_string(),
+                    single_side_lp_limit: None,
                 },
                 preset_holder_fields: covenant_holder::msg::PresetHolderFields {
                     withdrawer: Some(CREATOR_ADDR.to_string()),

--- a/contracts/lper/src/error.rs
+++ b/contracts/lper/src/error.rs
@@ -8,4 +8,7 @@ pub enum ContractError {
 
     #[error("Not clock")]
     ClockVerificationError {},
+
+    #[error("Single side LP limit exceeded")]
+    SingleSideLpLimitError {},
 }

--- a/contracts/lper/src/msg.rs
+++ b/contracts/lper/src/msg.rs
@@ -1,6 +1,6 @@
 use astroport::asset::Asset;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Decimal};
+use cosmwasm_std::{Addr, Decimal, Uint128};
 use covenant_clock_derive::clocked;
 
 use crate::state::ContractState;
@@ -13,6 +13,7 @@ pub struct InstantiateMsg {
     pub slippage_tolerance: Option<Decimal>,
     pub autostake: Option<bool>,
     pub assets: Vec<Asset>,
+    pub single_side_lp_limit: Decimal,
 }
 
 #[cw_serde]
@@ -20,6 +21,7 @@ pub struct PresetLpFields {
     pub slippage_tolerance: Option<Decimal>,
     pub autostake: Option<bool>,
     pub assets: Vec<Asset>,
+    pub single_side_lp_limit: Option<Decimal>,
     pub lp_code: u64,
     pub lp_position: String,
     pub label: String,
@@ -40,6 +42,10 @@ impl PresetLpFields {
             slippage_tolerance: self.slippage_tolerance,
             autostake: self.autostake,
             assets: self.assets,
+            single_side_lp_limit: self.single_side_lp_limit.unwrap_or(
+                // 5% default?
+                Decimal::from_ratio(Uint128::new(5), Uint128::new(100))
+            ),
         }
     }
 }

--- a/contracts/lper/src/state.rs
+++ b/contracts/lper/src/state.rs
@@ -14,6 +14,7 @@ pub const CONTRACT_STATE: Item<ContractState> = Item::new("contract_state");
 pub const AUTOSTAKE: Item<bool> = Item::new("autostake");
 pub const SLIPPAGE_TOLERANCE: Item<Decimal> = Item::new("slippage_tolerance");
 pub const ASSETS: Item<Vec<Asset>> = Item::new("assets");
+pub const SINGLE_SIDE_LP_LIMIT: Item<Decimal> = Item::new("single_side_lp_limit");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/lper/src/suite_test/suite.rs
+++ b/contracts/lper/src/suite_test/suite.rs
@@ -162,6 +162,7 @@ impl Default for SuiteBuilder {
                         amount: Uint128::new(100000),
                     },
                 ],
+                single_side_lp_limit: Decimal::from_ratio(Uint128::new(5), Uint128::new(100)),
             },
             token_instantiate: TokenInstantiateMsg {
                 name: "nativetoken".to_string(),


### PR DESCRIPTION
closes #30 
adds a check to providing single-sided liquidity with leftover assets in lper.
covenant accepts an optional ratio parameter that gets passed to LP on instantiation.
Default is currently set to 5%.