### PR TITLE
generalized liquid pooler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "cosmwasm-std",
  "covenant-clock",
  "covenant-macros",
+ "covenant-two-party-pol-holder",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "covenant-astroport-liquid-pooler",
  "covenant-clock",
  "covenant-ibc-forwarder",
  "covenant-interchain-router",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "covenant-astroport-liquid-pooler"
+version = "1.0.0"
+dependencies = [
+ "astroport 2.8.0",
+ "astroport-factory",
+ "astroport-native-coin-registry",
+ "astroport-pair-stable",
+ "astroport-token",
+ "astroport-whitelist",
+ "base64 0.13.1",
+ "bech32",
+ "cosmos-sdk-proto 0.14.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "covenant-clock",
+ "covenant-macros",
+ "cw-multi-test",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.2",
+ "cw1-whitelist 1.1.1",
+ "cw2 1.1.1",
+ "cw20 0.15.1",
+ "neutron-sdk",
+ "prost 0.11.9",
+ "prost-types",
+ "protobuf 3.3.0",
+ "schemars",
+ "serde",
+ "serde-json-wasm 0.4.1",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
 name = "covenant-clock"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ swap-covenant = { path = "contracts/swap-covenant" }
 covenant-interchain-router = { path = "contracts/interchain-router" }
 covenant-two-party-pol-holder = { path = "contracts/two-party-pol-holder" }
 covenant-two-party-pol = { path = "contracts/two-party-pol-covenant" }
+covenant-astroport-liquid-pooler = { path = "contracts/astroport-liquid-pooler" }
 
 # packages 
 clock-derive = { path = "packages/clock-derive" }

--- a/contracts/astroport-liquid-pooler/.cargo/config
+++ b/contracts/astroport-liquid-pooler/.cargo/config
@@ -1,0 +1,3 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+schema = "run --bin schema"

--- a/contracts/astroport-liquid-pooler/Cargo.toml
+++ b/contracts/astroport-liquid-pooler/Cargo.toml
@@ -59,3 +59,4 @@ astroport-factory =  {git = "https://github.com/astroport-fi/astroport-core.git"
 astroport-native-coin-registry = {git = "https://github.com/astroport-fi/astroport-core.git"}
 astroport-pair-stable = {git = "https://github.com/astroport-fi/astroport-core.git"}
 cw1-whitelist = "1.1.0"
+covenant-two-party-pol-holder = { workspace = true }

--- a/contracts/astroport-liquid-pooler/Cargo.toml
+++ b/contracts/astroport-liquid-pooler/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name        = "covenant-astroport-liquid-pooler"
+authors     = ["benskey bekauz@protonmail.com"]
+description = "Astroport LP contract for covenants"
+license     = { workspace = true }
+repository  = { workspace = true }
+version     = { workspace = true }
+edition     = { workspace = true }
+
+exclude = [
+  "contract.wasm",
+  "hash.txt",
+]
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+covenant-macros = { workspace = true }
+covenant-clock        = { workspace = true, features=["library"] }
+
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw-utils        = { workspace = true }
+cw2             = { workspace = true }
+serde           = { workspace = true }
+thiserror       = { workspace = true }
+# the sha2 version here is the same as the one used by
+# cosmwasm-std. when bumping cosmwasm-std, this should also be
+# updated. to find cosmwasm_std's sha function:
+# ```cargo tree --package cosmwasm-std```
+sha2             = { workspace = true }
+neutron-sdk      = { workspace = true }
+cosmos-sdk-proto = { workspace = true }
+protobuf         = { workspace = true }
+schemars         = { workspace = true }
+serde-json-wasm  = { workspace = true }
+base64           = { workspace = true }
+prost            = { workspace = true }
+prost-types      = { workspace = true }
+bech32           = { workspace = true }
+astroport        = "2.8.0"
+cw20             = { version = "0.15" }
+
+# dev-dependencies
+[dev-dependencies]
+cw-multi-test = { workspace = true }
+astroport-token = {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-whitelist = {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-factory =  {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-native-coin-registry = {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-pair-stable = {git = "https://github.com/astroport-fi/astroport-core.git"}
+cw1-whitelist = "1.1.0"

--- a/contracts/astroport-liquid-pooler/examples/schema.rs
+++ b/contracts/astroport-liquid-pooler/examples/schema.rs
@@ -1,0 +1,15 @@
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+use covenant_astroport_liquid_pooler::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+}

--- a/contracts/astroport-liquid-pooler/src/contract.rs
+++ b/contracts/astroport-liquid-pooler/src/contract.rs
@@ -57,7 +57,6 @@ pub fn instantiate(
     // store the relevant module addresses
     CLOCK_ADDRESS.save(deps.storage, &clock_addr)?;
     HOLDER_ADDRESS.save(deps.storage, &holder_addr)?;
-
     ASSETS.save(deps.storage, &msg.assets)?;
 
     let decimal_range = DecimalRange::try_from(
@@ -133,7 +132,7 @@ fn try_lp(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     )?;
     let a_to_b_ratio = Decimal::from_ratio(pool_token_a_bal, pool_token_b_bal);
     // validate the current pool ratio against our expectations
-    lp_config.expected_pool_ratio_range.is_within_range(a_to_b_ratio)?;
+    // lp_config.expected_pool_ratio_range.is_within_range(a_to_b_ratio)?;
 
     // first we query our own balances and filter out any unexpected denoms
     let bal_coins = deps
@@ -371,6 +370,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::LpConfig {} => Ok(to_binary(&LP_CONFIG.may_load(deps.storage)?)?),
         // the deposit address for LP module is the contract itself
         QueryMsg::DepositAddress {} => Ok(to_binary(&Some(&env.contract.address.to_string()))?),
+        QueryMsg::ProvidedLiquidityInfo {} => Ok(to_binary(&PROVIDED_LIQUIDITY_INFO.load(deps.storage)?)?),
     }
 }
 

--- a/contracts/astroport-liquid-pooler/src/contract.rs
+++ b/contracts/astroport-liquid-pooler/src/contract.rs
@@ -35,7 +35,7 @@ const SINGLE_SIDED_REPLY_ID: u64 = 322u64;
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
@@ -125,7 +125,7 @@ fn try_lp(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     )?;
     let a_to_b_ratio = Decimal::from_ratio(pool_token_a_bal, pool_token_b_bal);
     // validate the current pool ratio against our expectations
-    // lp_config.expected_pool_ratio_range.is_within_range(a_to_b_ratio)?;
+    lp_config.expected_pool_ratio_range.is_within_range(a_to_b_ratio)?;
 
     // first we query our own balances and filter out any unexpected denoms
     let bal_coins = deps

--- a/contracts/astroport-liquid-pooler/src/contract.rs
+++ b/contracts/astroport-liquid-pooler/src/contract.rs
@@ -1,5 +1,3 @@
-use std::ops::Sub;
-
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{

--- a/contracts/astroport-liquid-pooler/src/contract.rs
+++ b/contracts/astroport-liquid-pooler/src/contract.rs
@@ -1,0 +1,446 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdError, StdResult, SubMsg, Uint128, WasmMsg,
+};
+use covenant_clock::helpers::verify_clock;
+use cw2::set_contract_version;
+
+use astroport::{
+    asset::Asset,
+    pair::{ExecuteMsg::ProvideLiquidity, PoolResponse},
+    DecimalCheckedOps,
+};
+
+use crate::{
+    error::ContractError,
+    msg::{
+        ContractState, ExecuteMsg, InstantiateMsg, LpConfig, MigrateMsg, ProvidedLiquidityInfo,
+        QueryMsg,
+    },
+    state::{ASSETS, HOLDER_ADDRESS, LP_CONFIG, PROVIDED_LIQUIDITY_INFO},
+};
+
+use neutron_sdk::NeutronResult;
+
+use crate::state::{CLOCK_ADDRESS, CONTRACT_STATE};
+
+const CONTRACT_NAME: &str = "crates.io:covenant-astroport-liquid-pooler";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// type QueryDeps<'a> = Deps<'a, NeutronQuery>;
+// type ExecuteDeps<'a> = DepsMut<'a, NeutronQuery>;
+const DOUBLE_SIDED_REPLY_ID: u64 = 321u64;
+const SINGLE_SIDED_REPLY_ID: u64 = 322u64;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    deps.api.debug("WASMDEBUG: lp instantiate");
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // validate the contract addresses
+    let clock_addr = deps.api.addr_validate(&msg.clock_address)?;
+    let pool_addr = deps.api.addr_validate(&msg.pool_address)?;
+    let holder_addr = deps.api.addr_validate(&msg.holder_address)?;
+
+    // contract starts at Instantiated state
+    CONTRACT_STATE.save(deps.storage, &ContractState::Instantiated)?;
+
+    // store the relevant module addresses
+    CLOCK_ADDRESS.save(deps.storage, &clock_addr)?;
+    HOLDER_ADDRESS.save(deps.storage, &holder_addr)?;
+
+    ASSETS.save(deps.storage, &msg.assets)?;
+
+    let lp_config = LpConfig {
+        pool_address: pool_addr,
+        single_side_lp_limits: msg.single_side_lp_limits,
+        autostake: msg.autostake,
+        slippage_tolerance: msg.slippage_tolerance,
+    };
+    LP_CONFIG.save(deps.storage, &lp_config)?;
+
+    // we begin with no liquidity provided
+    PROVIDED_LIQUIDITY_INFO.save(
+        deps.storage,
+        &ProvidedLiquidityInfo {
+            provided_amount_a: Uint128::zero(),
+            provided_amount_b: Uint128::zero(),
+        },
+    )?;
+
+    Ok(Response::default()
+        .add_attribute("method", "lp_instantiate")
+        .add_attribute("clock_addr", clock_addr)
+        .add_attribute("holder_addr", holder_addr)
+        .add_attribute("asset_a_denom", msg.assets.asset_a_denom)
+        .add_attribute("asset_b_denom", msg.assets.asset_b_denom)
+        .add_attributes(lp_config.to_response_attributes()))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Tick {} => try_tick(deps, env, info),
+    }
+}
+
+/// attempts to advance the state machine. performs `info.sender` validation.
+fn try_tick(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+    // Verify caller is the clock
+    verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)?;
+
+    let current_state = CONTRACT_STATE.load(deps.storage)?;
+    match current_state {
+        ContractState::Instantiated => try_lp(deps, env),
+    }
+}
+
+/// method which attempts to provision liquidity to the pool.
+/// if both desired asset balances are non-zero, double sided liquidity
+/// is provided.
+/// otherwise, single-sided liquidity provision is attempted.
+fn try_lp(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
+    let asset_data = ASSETS.load(deps.storage)?;
+
+    // first we query our own balances and filter out any unexpected denoms
+    let bal_coins = deps
+        .querier
+        .query_all_balances(env.contract.address.to_string())?;
+    let (coin_a, coin_b) = get_relevant_balances(
+        bal_coins,
+        asset_data.asset_a_denom,
+        asset_data.asset_b_denom,
+    );
+
+    // depending on available balances we attempt a different action:
+    match (coin_a.amount.is_zero(), coin_b.amount.is_zero()) {
+        // one balance is non-zero, we attempt single-side
+        (true, false) | (false, true) => {
+            let single_sided_submsg =
+                try_get_single_side_lp_submsg(deps.branch(), coin_a, coin_b)?;
+            if let Some(msg) = single_sided_submsg {
+                return Ok(Response::default()
+                    .add_submessage(msg)
+                    .add_attribute("method", "single_side_lp"));
+            }
+        }
+        // both balances are non-zero, we attempt double-side
+        (false, false) => {
+            let double_sided_submsg =
+                try_get_double_side_lp_submsg(deps.branch(), coin_a, coin_b)?;
+
+            if let Some(msg) = double_sided_submsg {
+                return Ok(Response::default()
+                    .add_submessage(msg)
+                    .add_attribute("method", "double_side_lp"));
+            }
+        }
+        // both balances zero, no liquidity can be provisioned
+        _ => (),
+    }
+
+    // if no message could be constructed, we keep waiting for funds
+    Ok(Response::default()
+        .add_attribute("method", "try_lp")
+        .add_attribute("status", "not enough funds"))
+}
+
+/// attempts to get a double sided ProvideLiquidity submessage.
+/// amounts here do not matter. as long as we have non-zero balances of both
+/// a and b tokens, the maximum amount of liquidity is provided to maintain
+/// the existing pool ratio.
+fn try_get_double_side_lp_submsg(
+    deps: DepsMut,
+    token_a: Coin,
+    token_b: Coin,
+) -> Result<Option<SubMsg>, ContractError> {
+    let lp_config = LP_CONFIG.load(deps.storage)?;
+    let asset_data = ASSETS.load(deps.storage)?;
+    let holder_address = HOLDER_ADDRESS.load(deps.storage)?;
+
+    // we now query the pool to know the balances
+    let pool_response: PoolResponse = deps
+        .querier
+        .query_wasm_smart(&lp_config.pool_address, &astroport::pair::QueryMsg::Pool {})?;
+    let (pool_token_a_bal, pool_token_b_bal) = get_pool_asset_amounts(
+        pool_response.assets,
+        &asset_data.asset_a_denom.as_str(),
+        &asset_data.asset_b_denom.as_str(),
+    )?;
+
+    // we derive the ratio of token a to token b
+    // using this ratio we know how many of token a we should provide for every one b token
+    // by multiplying available b token amount by this ratio.
+    let a_to_b_ratio = Decimal::from_ratio(pool_token_a_bal, pool_token_b_bal);
+
+    // we thus find the required token amount to enter into the position using all available b tokens:
+    let required_token_a_amount = a_to_b_ratio.checked_mul_uint128(token_b.amount)?;
+
+    // depending on available balances we determine the highest amount
+    // of liquidity we can provide:
+    let (asset_a_double_sided, asset_b_double_sided) =
+        if token_a.amount >= required_token_a_amount {
+            // if we are able to satisfy the required amount, we do that:
+            // provide all b tokens along with required amount of a tokens
+            asset_data.to_tuple(required_token_a_amount, token_b.amount)
+        } else {
+            // otherwise, our token a amount is insufficient to provide double
+            // sided liquidity using all of our b tokens.
+            // this means that we should provide all of our available a tokens,
+            // and as many b tokens as needed to satisfy the existing ratio
+            asset_data.to_tuple(
+                token_a.amount,
+                Decimal::from_ratio(
+                    pool_token_b_bal,
+                     pool_token_a_bal
+                ).checked_mul_uint128(token_a.amount)?)
+        };
+
+    let (a_coin, b_coin) = (
+        asset_a_double_sided.to_coin()?,
+        asset_b_double_sided.to_coin()?,
+    );
+
+    // craft a ProvideLiquidity message with the determined assets
+    let double_sided_liq_msg = ProvideLiquidity {
+        assets: vec![asset_a_double_sided, asset_b_double_sided],
+        slippage_tolerance: lp_config.slippage_tolerance,
+        auto_stake: lp_config.autostake,
+        receiver: Some(holder_address.to_string()),
+    };
+
+    // update the provided amounts and leftover assets
+    PROVIDED_LIQUIDITY_INFO.update(
+        deps.storage,
+        |mut info: ProvidedLiquidityInfo| -> StdResult<_> {
+            info.provided_amount_b = info.provided_amount_b.checked_add(b_coin.amount)?;
+            info.provided_amount_a = info
+                .provided_amount_a
+                .checked_add(a_coin.amount)?;
+            Ok(info)
+        },
+    )?;
+
+    Ok(Some(SubMsg::reply_on_success(
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: lp_config.pool_address.to_string(),
+            msg: to_binary(&double_sided_liq_msg)?,
+            funds: vec![a_coin, b_coin],
+        }),
+        DOUBLE_SIDED_REPLY_ID,
+    )))
+}
+
+/// attempts to build a single sided `ProvideLiquidity` message.
+/// pool ratio does not get validated here. as long as the single
+/// side asset amount being provided is within our predefined
+/// single-side liquidity limits, we provide it.
+fn try_get_single_side_lp_submsg(
+    deps: DepsMut,
+    coin_a: Coin,
+    coin_b: Coin,
+) -> Result<Option<SubMsg>, ContractError> {
+    let asset_data = ASSETS.load(deps.storage)?;
+    let holder_address = HOLDER_ADDRESS.load(deps.storage)?;
+    let lp_config = LP_CONFIG.load(deps.storage)?;
+    
+    let assets = asset_data.to_asset_vec(coin_a.amount, coin_b.amount);
+
+    // given one non-zero asset, we build the ProvideLiquidity message
+    let single_sided_liq_msg = ProvideLiquidity {
+        assets,
+        slippage_tolerance: lp_config.slippage_tolerance,
+        auto_stake: lp_config.autostake,
+        receiver: Some(holder_address.to_string()),
+    };
+
+    // now we try to submit the message for either B or A token single side liquidity
+    if coin_a.amount.is_zero()
+        && coin_b.amount <= lp_config.single_side_lp_limits.asset_b_limit
+    {
+        // update the provided liquidity info
+        PROVIDED_LIQUIDITY_INFO.update(deps.storage, |mut info| -> StdResult<_> {
+            info.provided_amount_b = info.provided_amount_b.checked_add(coin_b.amount)?;
+            Ok(info)
+        })?;
+
+        // if available ls token amount is within single side limits we build a single side msg
+        let submsg = SubMsg::reply_on_success(
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: lp_config.pool_address.to_string(),
+                msg: to_binary(&single_sided_liq_msg)?,
+                funds: vec![coin_b],
+            }),
+            SINGLE_SIDED_REPLY_ID,
+        );
+
+        return Ok(Some(submsg));
+    } else if coin_b.amount.is_zero()
+        && coin_a.amount <= lp_config.single_side_lp_limits.asset_a_limit
+    {
+        // update the provided liquidity info
+        PROVIDED_LIQUIDITY_INFO.update(deps.storage, |mut info| -> StdResult<_> {
+            info.provided_amount_a =
+                info.provided_amount_a.checked_add(coin_a.amount)?;
+            Ok(info)
+        })?;
+
+        // if available A token amount is within single side limits we build a single side msg
+        let submsg = SubMsg::reply_on_success(
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: lp_config.pool_address.to_string(),
+                msg: to_binary(&single_sided_liq_msg)?,
+                funds: vec![coin_a],
+            }),
+            SINGLE_SIDED_REPLY_ID,
+        );
+
+        return Ok(Some(submsg));
+    }
+
+    // if neither a nor b token single side lp message was built, we just go back and wait
+    Ok(None)
+}
+
+/// filters out a vector of `Coin`s to retrieve ones with relevant denoms
+fn get_relevant_balances(coins: Vec<Coin>, a_denom: String, b_denom: String) -> (Coin, Coin) {
+    let (mut token_a, mut token_b) = (Coin::default(), Coin::default());
+
+    for c in coins {
+        if c.denom == a_denom {
+            // found token_a balance
+            token_a = c;
+        } else if c.denom == b_denom {
+            // found token_b balance
+            token_b = c;
+        }
+    }
+    (token_a, token_b)
+}
+
+/// filters out irrelevant balances and returns a and b token amounts
+fn get_pool_asset_amounts(
+    assets: Vec<Asset>,
+    a_denom: &str,
+    b_denom: &str,
+) -> Result<(Uint128, Uint128), StdError> {
+    let (mut a_bal, mut b_bal) = (Uint128::zero(), Uint128::zero());
+
+    for asset in assets {
+        let coin = asset.to_coin()?;
+        if coin.denom == b_denom {
+            // found b balance
+            b_bal = coin.amount;
+        } else if coin.denom == a_denom {
+            // found a token balance
+            a_bal = coin.amount;
+        }
+    }
+
+    Ok((a_bal, b_bal))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::ClockAddress {} => Ok(to_binary(&CLOCK_ADDRESS.may_load(deps.storage)?)?),
+        QueryMsg::ContractState {} => Ok(to_binary(&CONTRACT_STATE.may_load(deps.storage)?)?),
+        QueryMsg::HolderAddress {} => Ok(to_binary(&HOLDER_ADDRESS.may_load(deps.storage)?)?),
+        QueryMsg::Assets {} => Ok(to_binary(&ASSETS.may_load(deps.storage)?)?),
+        QueryMsg::LpConfig {} => Ok(to_binary(&LP_CONFIG.may_load(deps.storage)?)?),
+        // the deposit address for LP module is the contract itself
+        QueryMsg::DepositAddress {} => Ok(to_binary(&Some(&env.contract.address.to_string()))?),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> NeutronResult<Response> {
+    deps.api.debug("WASMDEBUG: migrate");
+
+    match msg {
+        MigrateMsg::UpdateConfig {
+            clock_addr,
+            holder_address,
+            assets,
+            lp_config,
+        } => {
+            let mut response = Response::default().add_attribute("method", "update_config");
+
+            if let Some(clock_addr) = clock_addr {
+                CLOCK_ADDRESS.save(deps.storage, &deps.api.addr_validate(&clock_addr)?)?;
+                response = response.add_attribute("clock_addr", clock_addr);
+            }
+
+            if let Some(holder_address) = holder_address {
+                HOLDER_ADDRESS.save(deps.storage, &deps.api.addr_validate(&holder_address)?)?;
+                response = response.add_attribute("holder_address", holder_address);
+            }
+
+            if let Some(denoms) = assets {
+                ASSETS.save(deps.storage, &denoms)?;
+                response = response.add_attribute("ls_denom", denoms.asset_b_denom.to_string());
+                response =
+                    response.add_attribute("native_denom", denoms.asset_a_denom.to_string());
+            }
+
+            if let Some(config) = lp_config {
+                // validate the address before storing it
+                deps.api.addr_validate(config.pool_address.as_str())?;
+                LP_CONFIG.save(deps.storage, &config)?;
+                response = response.add_attributes(config.to_response_attributes());
+            }
+
+            Ok(response)
+        }
+        MigrateMsg::UpdateCodeId { data: _ } => {
+            // This is a migrate message to update code id,
+            // Data is optional base64 that we can parse to any data we would like in the future
+            // let data: SomeStruct = from_binary(&data)?;
+            Ok(Response::default())
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    deps.api.debug("WASMDEBUG: reply");
+    match msg.id {
+        DOUBLE_SIDED_REPLY_ID => handle_double_sided_reply_id(deps, _env, msg),
+        SINGLE_SIDED_REPLY_ID => handle_single_sided_reply_id(deps, _env, msg),
+        _ => Err(ContractError::from(StdError::GenericErr {
+            msg: "err".to_string(),
+        })),
+    }
+}
+
+fn handle_double_sided_reply_id(
+    _deps: DepsMut,
+    _env: Env,
+    msg: Reply,
+) -> Result<Response, ContractError> {
+    Ok(Response::default()
+        .add_attribute("method", "handle_double_sided_reply_id")
+        .add_attribute("reply_id", msg.id.to_string()))
+}
+
+fn handle_single_sided_reply_id(
+    _deps: DepsMut,
+    _env: Env,
+    msg: Reply,
+) -> Result<Response, ContractError> {
+    Ok(Response::default()
+        .add_attribute("method", "handle_single_sided_reply_id")
+        .add_attribute("reply_id", msg.id.to_string()))
+}

--- a/contracts/astroport-liquid-pooler/src/contract.rs
+++ b/contracts/astroport-liquid-pooler/src/contract.rs
@@ -10,7 +10,7 @@ use cw2::set_contract_version;
 use astroport::{
     asset::{Asset, PairInfo},
     pair::{ExecuteMsg::ProvideLiquidity, PoolResponse},
-    DecimalCheckedOps, factory::PairsResponse,
+    DecimalCheckedOps,
 };
 
 use crate::{
@@ -127,6 +127,7 @@ fn try_lp(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     let pool_response: PoolResponse = deps
         .querier
         .query_wasm_smart(&lp_config.pool_address, &astroport::pair::QueryMsg::Pool {})?;
+
     let (pool_token_a_bal, pool_token_b_bal) = get_pool_asset_amounts(
         pool_response.assets,
         &asset_data.asset_a_denom.as_str(),
@@ -148,7 +149,7 @@ fn try_lp(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
 
     // depending on available balances we attempt a different action:
     match (coin_a.amount.is_zero(), coin_b.amount.is_zero()) {
-        // one balance is non-zero, we attempt single-side
+        // exactly one balance is non-zero, we attempt single-side
         (true, false) | (false, true) => {
             let single_sided_submsg =
                 try_get_single_side_lp_submsg(deps.branch(), coin_a, coin_b, lp_config, asset_data)?;
@@ -162,7 +163,6 @@ fn try_lp(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
         (false, false) => {
             let double_sided_submsg =
                 try_get_double_side_lp_submsg(deps.branch(), coin_a, coin_b, a_to_b_ratio, pool_token_a_bal, pool_token_b_bal, lp_config, asset_data)?;
-
             if let Some(msg) = double_sided_submsg {
                 return Ok(Response::default()
                     .add_submessage(msg)

--- a/contracts/astroport-liquid-pooler/src/contract.rs
+++ b/contracts/astroport-liquid-pooler/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     to_binary, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdError, StdResult, SubMsg, Uint128, WasmMsg,
+    StdError, StdResult, SubMsg, Uint128, WasmMsg, Addr,
 };
 use covenant_clock::helpers::verify_clock;
 use cw2::set_contract_version;
@@ -37,7 +37,7 @@ const SINGLE_SIDED_REPLY_ID: u64 = 322u64;
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
@@ -47,8 +47,10 @@ pub fn instantiate(
     // validate the contract addresses
     let clock_addr = deps.api.addr_validate(&msg.clock_address)?;
     let pool_addr = deps.api.addr_validate(&msg.pool_address)?;
-    let holder_addr = deps.api.addr_validate(&msg.holder_address)?;
 
+    // TODO: instantiate2 / remove this field from instantiateMsg
+    let holder_addr = env.contract.address;
+    
     // contract starts at Instantiated state
     CONTRACT_STATE.save(deps.storage, &ContractState::Instantiated)?;
 

--- a/contracts/astroport-liquid-pooler/src/error.rs
+++ b/contracts/astroport-liquid-pooler/src/error.rs
@@ -1,0 +1,39 @@
+use cosmwasm_std::{OverflowError, StdError};
+use neutron_sdk::NeutronError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    NeutronError(#[from] NeutronError),
+
+    #[error("{0}")]
+    OverflowError(#[from] OverflowError),
+
+    #[error("Not clock")]
+    ClockVerificationError {},
+
+    #[error("Single side LP limit exceeded")]
+    SingleSideLpLimitError {},
+
+    #[error("Non zero balances for single side liquidity")]
+    SingleSideLpNonZeroBalanceError {},
+
+    #[error("Zero balance for double side liquidity")]
+    DoubleSideLpZeroBalanceError {},
+
+    #[error("Insufficient funds for double sided LP")]
+    DoubleSideLpLimitError {},
+
+    #[error("Incomplete pool assets")]
+    IncompletePoolAssets {},
+
+    #[error("Pool validation error")]
+    PoolValidationError {},
+
+    #[error("Price range error")]
+    PriceRangeError {},
+}

--- a/contracts/astroport-liquid-pooler/src/error.rs
+++ b/contracts/astroport-liquid-pooler/src/error.rs
@@ -36,4 +36,7 @@ pub enum ContractError {
 
     #[error("Price range error")]
     PriceRangeError {},
+
+    #[error("Unknown holder address. Migrate update to set it.")]
+    MissingHolderError {},
 }

--- a/contracts/astroport-liquid-pooler/src/error.rs
+++ b/contracts/astroport-liquid-pooler/src/error.rs
@@ -39,4 +39,7 @@ pub enum ContractError {
 
     #[error("Unknown holder address. Migrate update to set it.")]
     MissingHolderError {},
+
+    #[error("Pair type mismatch")]
+    PairTypeMismatch {},
 }

--- a/contracts/astroport-liquid-pooler/src/lib.rs
+++ b/contracts/astroport-liquid-pooler/src/lib.rs
@@ -6,3 +6,7 @@ pub mod contract;
 pub mod error;
 pub mod msg;
 pub mod state;
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod suite_test;

--- a/contracts/astroport-liquid-pooler/src/lib.rs
+++ b/contracts/astroport-liquid-pooler/src/lib.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::unwrap_used, clippy::expect_used)]
+
+extern crate core;
+
+pub mod contract;
+pub mod error;
+pub mod msg;
+pub mod state;

--- a/contracts/astroport-liquid-pooler/src/msg.rs
+++ b/contracts/astroport-liquid-pooler/src/msg.rs
@@ -9,7 +9,6 @@ use crate::error::ContractError;
 pub struct InstantiateMsg {
     pub pool_address: String,
     pub clock_address: String,
-    pub holder_address: String,
     pub slippage_tolerance: Option<Decimal>,
     pub autostake: Option<bool>,
     pub assets: AssetData,
@@ -35,12 +34,10 @@ impl PresetAstroLiquidPoolerFields {
         &self,
         pool_address: String,
         clock_address: String,
-        holder_address: String,
     ) -> InstantiateMsg {
         InstantiateMsg { 
             pool_address,
             clock_address,
-            holder_address,
             slippage_tolerance: self.slippage_tolerance,
             autostake: self.autostake.clone(),
             assets: self.assets.clone(),

--- a/contracts/astroport-liquid-pooler/src/msg.rs
+++ b/contracts/astroport-liquid-pooler/src/msg.rs
@@ -15,6 +15,35 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+pub struct PresetAstroLiquidPoolerFields {
+    pub slippage_tolerance: Option<Decimal>,
+    pub autostake: Option<bool>,
+    pub assets: AssetData,
+    pub single_side_lp_limits: SingleSideLpLimits,
+    pub label: String,
+    pub code_id: u64,
+}
+
+impl PresetAstroLiquidPoolerFields {
+    pub fn to_instantiate_msg(
+        &self,
+        pool_address: String,
+        clock_address: String,
+        holder_address: String,
+    ) -> InstantiateMsg {
+        InstantiateMsg { 
+            pool_address,
+            clock_address,
+            holder_address,
+            slippage_tolerance: self.slippage_tolerance,
+            autostake: self.autostake.clone(),
+            assets: self.assets.clone(),
+            single_side_lp_limits: self.single_side_lp_limits.clone(),
+        }
+    }
+}
+
+#[cw_serde]
 pub struct LpConfig {
     /// address of the liquidity pool we plan to enter
     pub pool_address: Addr,

--- a/contracts/astroport-liquid-pooler/src/msg.rs
+++ b/contracts/astroport-liquid-pooler/src/msg.rs
@@ -1,4 +1,4 @@
-use astroport::asset::{Asset, AssetInfo};
+use astroport::{asset::{Asset, AssetInfo}, factory::PairType};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Attribute, Binary, Decimal, Uint128};
 use covenant_macros::{clocked, covenant_clock_address, covenant_deposit_address};
@@ -15,6 +15,7 @@ pub struct InstantiateMsg {
     pub single_side_lp_limits: SingleSideLpLimits,
     pub expected_pool_ratio: Decimal,
     pub acceptable_pool_ratio_delta: Decimal,
+    pub pair_type: PairType,
 }
 
 #[cw_serde]
@@ -27,6 +28,7 @@ pub struct PresetAstroLiquidPoolerFields {
     pub code_id: u64,
     pub expected_pool_ratio: Decimal,
     pub acceptable_pool_ratio_delta: Decimal,
+    pub pair_type: PairType,
 }
 
 impl PresetAstroLiquidPoolerFields {
@@ -44,6 +46,7 @@ impl PresetAstroLiquidPoolerFields {
             single_side_lp_limits: self.single_side_lp_limits.clone(),
             expected_pool_ratio: self.expected_pool_ratio,
             acceptable_pool_ratio_delta: self.acceptable_pool_ratio_delta,
+            pair_type: self.pair_type.clone(),
         }
     }
 }
@@ -87,6 +90,8 @@ pub struct LpConfig {
     pub slippage_tolerance: Option<Decimal>,
     /// expected price range
     pub expected_pool_ratio_range: DecimalRange,
+    /// pair type specified in the covenant
+    pub pair_type: PairType,
 }
 
 impl LpConfig {

--- a/contracts/astroport-liquid-pooler/src/msg.rs
+++ b/contracts/astroport-liquid-pooler/src/msg.rs
@@ -180,6 +180,8 @@ pub enum QueryMsg {
     Assets {},
     #[returns(LpConfig)]
     LpConfig {},
+    #[returns(ProvidedLiquidityInfo)]
+    ProvidedLiquidityInfo {},
 }
 
 #[cw_serde]

--- a/contracts/astroport-liquid-pooler/src/msg.rs
+++ b/contracts/astroport-liquid-pooler/src/msg.rs
@@ -1,0 +1,187 @@
+use astroport::asset::{Asset, AssetInfo};
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{Addr, Attribute, Binary, Decimal, Uint128};
+use covenant_macros::{clocked, covenant_clock_address, covenant_deposit_address};
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub pool_address: String,
+    pub clock_address: String,
+    pub holder_address: String,
+    pub slippage_tolerance: Option<Decimal>,
+    pub autostake: Option<bool>,
+    pub assets: AssetData,
+    pub single_side_lp_limits: SingleSideLpLimits,
+}
+
+#[cw_serde]
+pub struct LpConfig {
+    /// address of the liquidity pool we plan to enter
+    pub pool_address: Addr,
+    /// amounts of both tokens we consider ok to single-side lp
+    pub single_side_lp_limits: SingleSideLpLimits,
+    /// boolean flag for enabling autostaking of LP tokens upon liquidity provisioning
+    pub autostake: Option<bool>,
+    /// slippage tolerance parameter for liquidity provisioning
+    pub slippage_tolerance: Option<Decimal>,
+}
+
+impl LpConfig {
+    pub fn to_response_attributes(self) -> Vec<Attribute> {
+        let autostake = match self.autostake {
+            Some(val) => val.to_string(),
+            None => "None".to_string(),
+        };
+        let slippage_tolerance = match self.slippage_tolerance {
+            Some(val) => val.to_string(),
+            None => "None".to_string(),
+        };
+        vec![
+            Attribute::new("pool_address", self.pool_address.to_string()),
+            Attribute::new(
+                "single_side_asset_a_limit",
+                self.single_side_lp_limits.asset_a_limit.to_string(),
+            ),
+            Attribute::new(
+                "single_side_asset_b_limit",
+                self.single_side_lp_limits.asset_b_limit.to_string(),
+            ),
+            Attribute::new("autostake", autostake),
+            Attribute::new("slippage_tolerance", slippage_tolerance),
+        ]
+    }
+}
+
+/// holds the both asset denoms relevant for providing liquidity
+#[cw_serde]
+pub struct AssetData {
+    pub asset_a_denom: String,
+    pub asset_b_denom: String,
+}
+
+impl AssetData {
+    pub fn to_asset_vec(&self, a_bal: Uint128, b_bal: Uint128) -> Vec<Asset> {
+        vec![
+            Asset {
+                info: AssetInfo::NativeToken { denom: self.asset_a_denom.to_string() },
+                amount: a_bal,
+            },
+            Asset {
+                info: AssetInfo::NativeToken { denom: self.asset_b_denom.to_string() },
+                amount: b_bal,
+            },
+        ]
+    }
+
+    /// returns tuple of (asset_A, asset_B)
+    pub fn to_tuple(&self, a_bal: Uint128, b_bal: Uint128) -> (Asset, Asset) {
+        (
+            Asset {
+                info: AssetInfo::NativeToken { denom: self.asset_a_denom.to_string() },
+                amount: a_bal,
+            },
+            Asset {
+                info: AssetInfo::NativeToken { denom: self.asset_b_denom.to_string() },
+                amount: b_bal,
+            },
+        )
+    }
+}
+
+/// single side lp limits define the highest amount (in `Uint128`) that
+/// we consider acceptable to provide single-sided.
+/// if asset balance exceeds these limits, double-sided liquidity should be provided.
+#[cw_serde]
+pub struct SingleSideLpLimits {
+    pub asset_a_limit: Uint128,
+    pub asset_b_limit: Uint128,
+}
+
+/// Defines fields relevant to LP module that are known prior to covenant
+/// being instantiated. Use `to_instantiate_msg` implemented method to obtain
+/// the `InstantiateMsg` by providing the non-deterministic fields.
+#[cw_serde]
+pub struct PresetLpFields {
+    /// slippage tolerance for providing liquidity
+    pub slippage_tolerance: Option<Decimal>,
+    /// determines whether provided liquidity is automatically staked
+    pub autostake: Option<bool>,
+    /// denominations of both assets
+    pub assets: AssetData,
+    /// limits (in `Uint128`) for single side liquidity provision.
+    /// Defaults to 100 if none are provided.
+    pub single_side_lp_limits: Option<SingleSideLpLimits>,
+    /// lp contract code
+    pub lp_code: u64,
+    /// label for contract to be instantiated with
+    pub label: String,
+    /// address of the target liquidity pool
+    pub pool_address: String,
+}
+
+impl PresetLpFields {
+    /// builds an `InstantiateMsg` by taking in any fields not known on instantiation.
+    pub fn to_instantiate_msg(
+        self,
+        clock_address: String,
+        holder_address: String,
+    ) -> InstantiateMsg {
+        InstantiateMsg {
+            pool_address: self.pool_address,
+            clock_address,
+            holder_address,
+            slippage_tolerance: self.slippage_tolerance,
+            autostake: self.autostake,
+            assets: self.assets,
+            single_side_lp_limits: self.single_side_lp_limits.unwrap_or(SingleSideLpLimits {
+                asset_a_limit: Uint128::new(100),
+                asset_b_limit: Uint128::new(100),
+            }),
+        }
+    }
+}
+
+#[clocked]
+#[cw_serde]
+pub enum ExecuteMsg {}
+
+#[covenant_clock_address]
+#[covenant_deposit_address]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(ContractState)]
+    ContractState {},
+    #[returns(Addr)]
+    HolderAddress {},
+    #[returns(Vec<Asset>)]
+    Assets {},
+    #[returns(LpConfig)]
+    LpConfig {},
+}
+
+#[cw_serde]
+pub enum MigrateMsg {
+    UpdateConfig {
+        clock_addr: Option<String>,
+        holder_address: Option<String>,
+        assets: Option<AssetData>,
+        lp_config: Option<LpConfig>,
+    },
+    UpdateCodeId {
+        data: Option<Binary>,
+    },
+}
+
+/// keeps track of provided asset liquidities in `Uint128`.
+#[cw_serde]
+pub struct ProvidedLiquidityInfo {
+    pub provided_amount_a: Uint128,
+    pub provided_amount_b: Uint128,
+}
+
+/// state of the LP state machine
+#[cw_serde]
+pub enum ContractState {
+    Instantiated,
+}

--- a/contracts/astroport-liquid-pooler/src/state.rs
+++ b/contracts/astroport-liquid-pooler/src/state.rs
@@ -1,0 +1,22 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+use crate::msg::{AssetData, ContractState, LpConfig, ProvidedLiquidityInfo};
+
+/// contract state tracks the state machine progress
+pub const CONTRACT_STATE: Item<ContractState> = Item::new("contract_state");
+
+/// asset denom information
+pub const ASSETS: Item<AssetData> = Item::new("assets");
+
+/// clock module address to verify the incoming ticks sender
+pub const CLOCK_ADDRESS: Item<Addr> = Item::new("clock_address");
+/// holder module address to verify withdrawal requests
+pub const HOLDER_ADDRESS: Item<Addr> = Item::new("holder_address");
+
+/// keeps track of both token amounts we provided to the pool
+pub const PROVIDED_LIQUIDITY_INFO: Item<ProvidedLiquidityInfo> =
+    Item::new("provided_liquidity_info");
+
+/// configuration relevant to entering into an LP position
+pub const LP_CONFIG: Item<LpConfig> = Item::new("lp_config");

--- a/contracts/astroport-liquid-pooler/src/suite_test/mod.rs
+++ b/contracts/astroport-liquid-pooler/src/suite_test/mod.rs
@@ -1,0 +1,2 @@
+mod suite;
+mod tests;

--- a/contracts/astroport-liquid-pooler/src/suite_test/suite.rs
+++ b/contracts/astroport-liquid-pooler/src/suite_test/suite.rs
@@ -1,0 +1,664 @@
+use astroport::{
+    asset::{Asset, AssetInfo, PairInfo},
+    factory::{PairConfig, PairType},
+    pair::{Cw20HookMsg, PoolResponse, SimulationResponse, StablePoolParams},
+};
+
+use cosmwasm_std::{
+    testing::MockApi, to_binary, Addr, Coin, Decimal, Empty, MemoryStorage, QueryRequest, Uint128,
+    Uint64, WasmQuery,
+};
+use cw20::Cw20ExecuteMsg;
+use cw_multi_test::{
+    App, AppResponse, BankKeeper, BankSudo, Contract, ContractWrapper, Executor, FailingModule,
+    SudoMsg, WasmKeeper,
+};
+use neutron_sdk::bindings::{msg::NeutronMsg, query::NeutronQuery};
+
+use crate::msg::{AssetData, InstantiateMsg, LpConfig, QueryMsg, SingleSideLpLimits, MigrateMsg};
+use astroport::factory::InstantiateMsg as FactoryInstantiateMsg;
+use astroport::native_coin_registry::InstantiateMsg as NativeCoinRegistryInstantiateMsg;
+use astroport::pair::InstantiateMsg as PairInstantiateMsg;
+use astroport::token::InstantiateMsg as TokenInstantiateMsg;
+use cw1_whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
+
+pub const CREATOR_ADDR: &str = "creator";
+pub const TOKEN_A_DENOM: &str = "uatom";
+pub const TOKEN_B_DENOM: &str = "untrn";
+
+fn astro_token() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            astroport_token::contract::execute,
+            astroport_token::contract::instantiate,
+            astroport_token::contract::query,
+        )
+        .with_migrate(astroport_token::contract::migrate),
+    )
+}
+
+fn astro_whitelist() -> Box<dyn Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        astroport_whitelist::contract::instantiate,
+        astroport_whitelist::contract::instantiate,
+        astroport_whitelist::contract::query,
+    ))
+}
+
+fn astro_factory() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            astroport_factory::contract::execute,
+            astroport_factory::contract::instantiate,
+            astroport_factory::contract::query,
+        )
+        .with_migrate(astroport_factory::contract::migrate)
+        .with_reply(astroport_factory::contract::reply),
+    )
+}
+
+fn astro_pair_stable() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            astroport_pair_stable::contract::execute,
+            astroport_pair_stable::contract::instantiate,
+            astroport_pair_stable::contract::query,
+        )
+        .with_reply(astroport_pair_stable::contract::reply)
+        .with_migrate(astroport_pair_stable::contract::migrate),
+    )
+}
+
+fn astro_coin_registry() -> Box<dyn Contract<Empty>> {
+    let registry_contract = ContractWrapper::new(
+        astroport_native_coin_registry::contract::execute,
+        astroport_native_coin_registry::contract::instantiate,
+        astroport_native_coin_registry::contract::query,
+    )
+    .with_migrate(astroport_native_coin_registry::contract::migrate);
+
+    Box::new(registry_contract)
+}
+
+fn lper_contract() -> Box<dyn Contract<Empty>> {
+    let lp_contract = ContractWrapper::new(
+        crate::contract::execute,
+        crate::contract::instantiate,
+        crate::contract::query,
+    )
+    .with_reply(crate::contract::reply)
+    .with_migrate(crate::contract::migrate);
+
+    Box::new(lp_contract)
+}
+
+fn clock_contract() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            covenant_clock::contract::execute,
+            covenant_clock::contract::instantiate,
+            covenant_clock::contract::query,
+        )
+        .with_reply(covenant_clock::contract::reply)
+        .with_migrate(covenant_clock::contract::migrate),
+    )
+}
+
+#[allow(unused)]
+pub type BaseApp = App<
+    BankKeeper,
+    MockApi,
+    MemoryStorage,
+    FailingModule<NeutronMsg, NeutronQuery, Empty>,
+    WasmKeeper<NeutronMsg, NeutronQuery>,
+>;
+#[allow(unused)]
+pub(crate) struct Suite {
+    pub app: App,
+    pub admin: Addr,
+    pub lp_token: Addr,
+    // (token_code, contract_address)
+    pub token: u64,
+    pub whitelist: (u64, String),
+    pub factory: (u64, String),
+    pub stable_pair: (u64, String),
+    pub coin_registry: (u64, String),
+    pub liquid_pooler: (u64, String),
+    pub clock_addr: String,
+    pub holder_addr: String,
+}
+
+pub(crate) struct SuiteBuilder {
+    pub lp_instantiate: InstantiateMsg,
+    pub token_instantiate: TokenInstantiateMsg,
+    pub whitelist_instantiate: WhitelistInstantiateMsg,
+    pub factory_instantiate: FactoryInstantiateMsg,
+    pub stablepair_instantiate: PairInstantiateMsg,
+    pub registry_instantiate: NativeCoinRegistryInstantiateMsg,
+    pub clock_instantiate: covenant_clock::msg::InstantiateMsg,
+}
+
+impl Default for SuiteBuilder {
+    fn default() -> Self {
+        Self {
+            lp_instantiate: InstantiateMsg {
+                clock_address: "clock-addr".to_string(),
+                pool_address: "lp-addr".to_string(),
+                slippage_tolerance: Some(Decimal::one()),
+                autostake: Some(false),
+                assets: AssetData {
+                    asset_a_denom: "uatom".to_string(),
+                    asset_b_denom: "untrn".to_string(),
+                },
+                single_side_lp_limits: SingleSideLpLimits {
+                    asset_a_limit: Uint128::new(100),
+                    asset_b_limit: Uint128::new(1000),
+                },
+                expected_pool_ratio: Decimal::from_ratio(Uint128::new(1), Uint128::new(10)),
+                acceptable_pool_ratio_delta: Decimal::from_ratio(Uint128::one(), Uint128::new(100)),
+                pair_type: PairType::Stable {},
+            },
+            token_instantiate: TokenInstantiateMsg {
+                name: "nativetoken".to_string(),
+                symbol: "ntk".to_string(),
+                decimals: 20,
+                initial_balances: vec![],
+                mint: None,
+                marketing: None,
+            },
+            whitelist_instantiate: WhitelistInstantiateMsg {
+                admins: vec![CREATOR_ADDR.to_string()],
+                mutable: false,
+            },
+            factory_instantiate: FactoryInstantiateMsg {
+                pair_configs: vec![PairConfig {
+                    code_id: u64::MAX,
+                    pair_type: astroport::factory::PairType::Stable {},
+                    total_fee_bps: 0,
+                    maker_fee_bps: 0,
+                    is_disabled: false,
+                    is_generator_disabled: true,
+                }],
+                token_code_id: u64::MAX,
+                fee_address: None,
+                generator_address: None,
+                owner: CREATOR_ADDR.to_string(),
+                whitelist_code_id: u64::MAX,
+                coin_registry_address: "TODO".to_string(),
+            },
+            stablepair_instantiate: PairInstantiateMsg {
+                asset_infos: vec![
+                    astroport::asset::AssetInfo::NativeToken {
+                        denom: TOKEN_A_DENOM.to_string(),
+                    },
+                    astroport::asset::AssetInfo::NativeToken {
+                        denom: TOKEN_B_DENOM.to_string(),
+                    },
+                ],
+                token_code_id: u64::MAX,
+                factory_addr: "TODO".to_string(),
+                init_params: Some(
+                    to_binary(&StablePoolParams {
+                        amp: 1000,
+                        owner: Some(CREATOR_ADDR.to_string()),
+                    })
+                    .unwrap(),
+                ),
+            },
+            registry_instantiate: NativeCoinRegistryInstantiateMsg {
+                owner: CREATOR_ADDR.to_string(),
+            },
+            clock_instantiate: covenant_clock::msg::InstantiateMsg {
+                tick_max_gas: Some(Uint64::new(50000)),
+                // this is the lper, if any instantiate flow changes, this needs to be updated
+                whitelist: vec!["contract9".to_string()],
+            },
+        }
+    }
+}
+
+#[allow(unused)]
+impl SuiteBuilder {
+    fn with_slippage_tolerance(mut self, decimal: Decimal) -> Self {
+        self.lp_instantiate.slippage_tolerance = Some(decimal);
+        self
+    }
+
+    fn with_autostake(mut self, autosake: Option<bool>) -> Self {
+        self.lp_instantiate.autostake = autosake;
+        self
+    }
+
+    fn with_assets(mut self, assets: AssetData) -> Self {
+        self.lp_instantiate.assets = assets;
+        self
+    }
+
+    fn with_token_instantiate_msg(mut self, msg: TokenInstantiateMsg) -> Self {
+        self.token_instantiate = msg;
+        self
+    }
+    
+    pub fn with_expected_pair_type(mut self, pair_type: PairType) -> Self {
+        self.lp_instantiate.pair_type = pair_type;
+        self
+    }
+
+    pub fn build(mut self) -> Suite {
+        // let mut app = BasicAppBuilder::<NeutronMsg, NeutronQuery>::new_custom().build(|_,_,_| {});
+
+        let mut app = App::default();
+
+        let token_code = app.store_code(astro_token());
+        let stablepair_code = app.store_code(astro_pair_stable());
+        let whitelist_code = app.store_code(astro_whitelist());
+        let coin_registry_code = app.store_code(astro_coin_registry());
+        let factory_code = app.store_code(astro_factory());
+        let lper_code = app.store_code(lper_contract());
+        let clock_code = app.store_code(clock_contract());
+
+        let clock_address = app
+            .instantiate_contract(
+                clock_code,
+                Addr::unchecked(CREATOR_ADDR),
+                &self.clock_instantiate,
+                &[],
+                "clock",
+                None,
+            )
+            .unwrap();
+
+        self.lp_instantiate.clock_address = clock_address.to_string();
+        self.factory_instantiate.token_code_id = token_code;
+        self.stablepair_instantiate.token_code_id = token_code;
+        self.factory_instantiate.whitelist_code_id = whitelist_code;
+        self.factory_instantiate.pair_configs[0].code_id = stablepair_code;
+
+        let whitelist_addr = app
+            .instantiate_contract(
+                whitelist_code,
+                Addr::unchecked(CREATOR_ADDR),
+                &self.whitelist_instantiate,
+                &[],
+                "whitelist",
+                None,
+            )
+            .unwrap();
+
+        app.update_block(|b: &mut cosmwasm_std::BlockInfo| b.height += 5);
+
+        let coin_registry_addr = app
+            .instantiate_contract(
+                coin_registry_code,
+                Addr::unchecked(CREATOR_ADDR),
+                &self.registry_instantiate,
+                &[],
+                "native coin registry",
+                None,
+            )
+            .unwrap();
+        app.update_block(|b| b.height += 5);
+
+        // add coins to registry
+        app.execute_contract(
+            Addr::unchecked(CREATOR_ADDR),
+            coin_registry_addr.clone(),
+            &astroport::native_coin_registry::ExecuteMsg::Add {
+                native_coins: vec![
+                    (TOKEN_A_DENOM.to_string(), 6),
+                    (TOKEN_B_DENOM.to_string(), 6),
+                ],
+            },
+            &[],
+        )
+        .unwrap();
+        app.update_block(|b| b.height += 5);
+
+        self.factory_instantiate.coin_registry_address = coin_registry_addr.to_string();
+
+        let factory_addr = app
+            .instantiate_contract(
+                factory_code,
+                Addr::unchecked(CREATOR_ADDR),
+                &self.factory_instantiate,
+                &[],
+                "factory",
+                None,
+            )
+            .unwrap();
+        app.update_block(|b| b.height += 5);
+
+        let init_pair_msg = astroport::factory::ExecuteMsg::CreatePair {
+            pair_type: PairType::Stable {},
+            asset_infos: vec![
+                AssetInfo::NativeToken {
+                    denom: TOKEN_A_DENOM.to_string(),
+                },
+                AssetInfo::NativeToken {
+                    denom: TOKEN_B_DENOM.to_string(),
+                },
+            ],
+            init_params: Some(
+                to_binary(&StablePoolParams {
+                    owner: Some(CREATOR_ADDR.to_string()),
+                    amp: 10,
+                })
+                .unwrap(),
+            ),
+        };
+        app.update_block(|b| b.height += 5);
+
+        let pair_msg = app
+            .execute_contract(
+                Addr::unchecked(CREATOR_ADDR),
+                factory_addr.clone(),
+                &init_pair_msg,
+                &[],
+            )
+            .unwrap();
+        app.update_block(|b| b.height += 5);
+
+        let pair_info: PairInfo = app
+            .wrap()
+            .query_wasm_smart(
+                &factory_addr,
+                &astroport::factory::QueryMsg::Pair {
+                    asset_infos: vec![
+                        AssetInfo::NativeToken {
+                            denom: TOKEN_A_DENOM.to_string(),
+                        },
+                        AssetInfo::NativeToken {
+                            denom: TOKEN_B_DENOM.to_string(),
+                        },
+                    ],
+                },
+            )
+            .unwrap();
+
+        self.stablepair_instantiate.factory_addr = factory_addr.to_string();
+        app.update_block(|b| b.height += 5);
+
+        let stable_pair_addr = app
+            .instantiate_contract(
+                stablepair_code,
+                Addr::unchecked(CREATOR_ADDR),
+                &self.stablepair_instantiate,
+                &[],
+                "stableswap",
+                None,
+            )
+            .unwrap();
+
+        app.update_block(|b| b.height += 5);
+
+        self.lp_instantiate.pool_address = stable_pair_addr.to_string();
+
+        let lper_address = app
+            .instantiate_contract(
+                lper_code,
+                Addr::unchecked(CREATOR_ADDR),
+                &self.lp_instantiate,
+                &[],
+                "lper contract",
+                Some(CREATOR_ADDR.to_string()),
+            )
+            .unwrap();
+        app.update_block(|b| b.height += 5);
+
+        app.migrate_contract(
+            Addr::unchecked(CREATOR_ADDR),
+            lper_address.clone(),
+            &MigrateMsg::UpdateConfig {
+                clock_addr: None,
+                holder_address: Some(CREATOR_ADDR.to_string()),
+                assets: None,
+                lp_config: None,
+            },
+            lper_code,
+        ).unwrap();
+
+        Suite {
+            app,
+            admin: Addr::unchecked(CREATOR_ADDR),
+            lp_token: pair_info.liquidity_token,
+            token: token_code,
+            whitelist: (whitelist_code, whitelist_addr.to_string()),
+            factory: (factory_code, factory_addr.to_string()),
+            stable_pair: (stablepair_code, stable_pair_addr.to_string()),
+            coin_registry: (coin_registry_code, coin_registry_addr.to_string()),
+            liquid_pooler: (lper_code, lper_address.to_string()),
+            clock_addr: clock_address.to_string(),
+            holder_addr: CREATOR_ADDR.to_string(),
+        }
+    }
+}
+
+// queries
+#[allow(unused)]
+impl Suite {
+    pub fn query_clock_address(&self) -> String {
+        self.app
+            .wrap()
+            .query_wasm_smart(&self.liquid_pooler.1, &QueryMsg::ClockAddress {})
+            .unwrap()
+    }
+
+    pub fn query_lp_position(&self) -> String {
+        let lp_config: LpConfig = self
+            .app
+            .wrap()
+            .query_wasm_smart(&self.liquid_pooler.1, &QueryMsg::LpConfig {})
+            .unwrap();
+        lp_config.pool_address.to_string()
+    }
+
+    pub fn query_contract_state(&self) -> String {
+        self.app
+            .wrap()
+            .query_wasm_smart(&self.liquid_pooler.1, &QueryMsg::ContractState {})
+            .unwrap()
+    }
+
+    pub fn query_holder_address(&self) -> String {
+        self.app
+            .wrap()
+            .query_wasm_smart(&self.liquid_pooler.1, &QueryMsg::HolderAddress {})
+            .unwrap()
+    }
+
+    pub fn query_assets(&self) -> Vec<Asset> {
+        self.app
+            .wrap()
+            .query_wasm_smart(&self.liquid_pooler.1, &QueryMsg::Assets {})
+            .unwrap()
+    }
+
+    pub fn query_addr_balances(&self, addr: Addr) -> Vec<Coin> {
+        self.app.wrap().query_all_balances(addr).unwrap()
+    }
+
+    pub fn query_pool_info(&self) -> PoolResponse {
+        self.app
+            .wrap()
+            .query(&QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: self.stable_pair.clone().1,
+                msg: to_binary(&astroport::pair::QueryMsg::Pool {}).unwrap(),
+            }))
+            .unwrap()
+    }
+
+    pub fn query_pool_share(&self) -> Vec<Asset> {
+        self.app
+            .wrap()
+            .query_wasm_smart(
+                Addr::unchecked(self.stable_pair.clone().1),
+                &astroport::pair::QueryMsg::Share {
+                    amount: Uint128::one(),
+                },
+            )
+            .unwrap()
+    }
+
+    pub fn query_simulation(&self, addr: String) -> SimulationResponse {
+        let query = astroport::pair::QueryMsg::Simulation {
+            offer_asset: Asset {
+                info: AssetInfo::NativeToken {
+                    denom: TOKEN_A_DENOM.to_string(),
+                },
+                amount: Uint128::one(),
+            },
+            // ask_asset_info: None,
+            ask_asset_info: Some(AssetInfo::NativeToken {
+                denom: TOKEN_B_DENOM.to_string(),
+            }),
+        };
+        println!("\nquerying simulation: {query:?}\n");
+
+        self.app.wrap().query_wasm_smart(addr, &query).unwrap()
+    }
+
+    pub fn query_contract_config(&self, addr: String) -> String {
+        let bytes = self
+            .app
+            .wrap()
+            .query_wasm_raw(addr, b"config")
+            .transpose()
+            .unwrap()
+            .unwrap();
+        match std::str::from_utf8(&bytes) {
+            Ok(v) => v.to_string(),
+            Err(e) => panic!("Invalid UTF-8 sequence: {e}"),
+        }
+    }
+
+    pub fn query_cw20_bal(&self, token: String, addr: String) -> cw20::BalanceResponse {
+        self.app
+            .wrap()
+            .query_wasm_smart(token, &cw20::Cw20QueryMsg::Balance { address: addr })
+            .unwrap()
+    }
+
+    pub fn query_liquidity_token_addr(&self) -> astroport::asset::PairInfo {
+        self.app
+            .wrap()
+            .query_wasm_smart(
+                self.stable_pair.1.to_string(),
+                &astroport::pair::QueryMsg::Pair {},
+            )
+            .unwrap()
+    }
+}
+
+// assertion helpers
+impl Suite {}
+
+impl Suite {
+    // tick LPer
+    pub fn tick(&mut self) -> AppResponse {
+        self.app
+            .execute_contract(
+                Addr::unchecked(self.clock_addr.to_string()),
+                Addr::unchecked(self.liquid_pooler.1.to_string()),
+                &crate::msg::ExecuteMsg::Tick {},
+                &[],
+            )
+            .unwrap()
+    }
+
+    // mint coins
+    pub fn mint_coins_to_addr(&mut self, address: String, denom: String, amount: Uint128) {
+        self.app
+            .sudo(SudoMsg::Bank(BankSudo::Mint {
+                to_address: address,
+                amount: vec![Coin { amount, denom }],
+            }))
+            .unwrap();
+    }
+
+    // pass time
+    pub fn pass_blocks(&mut self, num: u64) {
+        self.app.update_block(|b| b.height += num)
+    }
+
+    // withdraw liquidity from pool
+    #[allow(unused)]
+    pub fn withdraw_liquidity(
+        &mut self,
+        sender: Addr,
+        amount: u128,
+        assets: Vec<Asset>,
+    ) -> AppResponse {
+        self.app
+            .execute_contract(
+                sender,
+                Addr::unchecked("contract6".to_string()),
+                &Cw20ExecuteMsg::Send {
+                    contract: self.stable_pair.1.to_string(),
+                    amount: Uint128::from(amount),
+                    msg: to_binary(&Cw20HookMsg::WithdrawLiquidity { assets }).unwrap(),
+                },
+                &[],
+            )
+            .unwrap()
+    }
+
+    pub fn provide_manual_liquidity(
+        &mut self,
+        from: String,
+        token_a_amt: Uint128,
+        token_b_amt: Uint128,
+    ) -> AppResponse {
+        let _stable_pair_addr = self.stable_pair.1.to_string();
+
+        let balances = vec![
+            Coin {
+                denom: TOKEN_A_DENOM.to_string(),
+                amount: token_a_amt,
+            },
+            Coin {
+                denom: TOKEN_B_DENOM.to_string(),
+                amount: token_b_amt,
+            },
+        ];
+
+        let assets = vec![
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: TOKEN_A_DENOM.to_string(),
+                },
+                amount: token_a_amt,
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: TOKEN_B_DENOM.to_string(),
+                },
+                amount: token_b_amt,
+            },
+        ];
+
+        self.mint_coins_to_addr(
+            from.clone(),
+            TOKEN_A_DENOM.to_string(),
+            token_a_amt,
+        );
+        self.mint_coins_to_addr(from.clone(), TOKEN_B_DENOM.to_string(), token_b_amt);
+
+        let provide_liquidity_msg = astroport::pair::ExecuteMsg::ProvideLiquidity {
+            assets,
+            slippage_tolerance: None,
+            auto_stake: Some(false),
+            receiver: Some(from.clone()),
+        };
+
+        self.pass_blocks(10);
+
+        self.app
+            .execute_contract(
+                Addr::unchecked(from),
+                Addr::unchecked(self.stable_pair.1.to_string()),
+                &provide_liquidity_msg,
+                &balances,
+            )
+            .unwrap()
+    }
+}

--- a/contracts/astroport-liquid-pooler/src/suite_test/tests.rs
+++ b/contracts/astroport-liquid-pooler/src/suite_test/tests.rs
@@ -1,0 +1,199 @@
+use cosmwasm_std::{Addr, Uint128, Coin};
+
+use crate::suite_test::suite::{TOKEN_A_DENOM, TOKEN_B_DENOM};
+
+use super::suite::SuiteBuilder;
+
+#[test]
+fn test_double_sided_lp() {
+    let mut suite = SuiteBuilder::default().build();
+
+    // fund pool with balanced amounts of underlying tokens
+    let token_a_amt = Uint128::new(1000);
+    let token_b_amt = Uint128::new(10000);
+    suite.provide_manual_liquidity("alice".to_string(), token_a_amt, token_b_amt);
+
+    // fund LP contract with some tokens to provide liquidity with
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_A_DENOM.to_string(),
+        token_a_amt,
+    );
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_B_DENOM.to_string(),
+        token_b_amt,
+    );
+
+    let liquid_pooler_balances =
+        suite.query_addr_balances(Addr::unchecked(suite.liquid_pooler.1.to_string()));
+    assert_eq!(liquid_pooler_balances[0].amount, token_a_amt);
+    assert_eq!(liquid_pooler_balances[1].amount, token_b_amt);
+
+    let liquidity_token_addr = suite.query_liquidity_token_addr().liquidity_token.to_string();
+
+    let holder_balances = suite.query_cw20_bal(
+        liquidity_token_addr.clone(),
+        suite.holder_addr.to_string());
+    assert_eq!(Uint128::zero(), holder_balances.balance);
+
+    suite.pass_blocks(10);
+    suite.tick();
+
+    let liquid_pooler_balances =
+        suite.query_addr_balances(Addr::unchecked(suite.liquid_pooler.1.to_string()));
+    assert_eq!(0usize, liquid_pooler_balances.len());
+
+    let holder_balances = suite.query_cw20_bal(
+        liquidity_token_addr.to_string(),
+        suite.holder_addr.to_string(),
+    );
+    assert_ne!(Uint128::zero(), holder_balances.balance);
+}
+
+#[test]
+fn test_double_and_single_sided_lp() {
+    let mut suite = SuiteBuilder::default().build();
+
+    // fund pool with balanced amounts of underlying tokens at 1:10 ratio
+
+    suite.provide_manual_liquidity("alice".to_string(), Uint128::new(10000), Uint128::new(100000));
+
+    // fund LP contract with some tokens to provide liquidity with
+    let token_a_amt = Uint128::new(1000);
+    let token_b_amt = Uint128::new(9000);
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_A_DENOM.to_string(),
+        token_a_amt,
+    );
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_B_DENOM.to_string(),
+        token_b_amt,
+    );
+    let liquid_pooler_balances =
+        suite.query_addr_balances(Addr::unchecked(suite.liquid_pooler.1.to_string()));
+    assert_eq!(liquid_pooler_balances[0].amount, token_a_amt);
+    assert_eq!(liquid_pooler_balances[1].amount, token_b_amt);
+
+    let liquidity_token_addr = suite.query_liquidity_token_addr().liquidity_token.to_string();
+
+    let holder_balances = suite.query_cw20_bal(
+        liquidity_token_addr.clone(),
+        suite.holder_addr.to_string());
+    assert_eq!(Uint128::zero(), holder_balances.balance);
+
+    suite.pass_blocks(10);
+    suite.tick();
+
+    let liquid_pooler_balances =
+        suite.query_addr_balances(Addr::unchecked(suite.liquid_pooler.1.to_string()));
+    
+    // assert there are 100 uatoms remaining because of missmatched pool/provision ratio
+    assert_eq!(
+        Coin { denom: TOKEN_A_DENOM.to_string(), amount: Uint128::new(100) },
+        liquid_pooler_balances[0],
+    );
+    let holder_balance = suite.query_cw20_bal(
+        liquidity_token_addr.to_string(),
+        suite.holder_addr.to_string(),
+    ).balance;
+    assert_ne!(Uint128::zero(), holder_balance);
+
+    // tick again
+    suite.pass_blocks(10);
+    suite.tick();
+
+    let liquid_pooler_balances =
+        suite.query_addr_balances(Addr::unchecked(suite.liquid_pooler.1.to_string()));
+    assert_eq!(0, liquid_pooler_balances.len());
+
+    let new_holder_balance = suite.query_cw20_bal(
+        liquidity_token_addr.to_string(),
+        suite.holder_addr.to_string(),
+    ).balance;
+    assert_ne!(holder_balance, new_holder_balance);
+}
+
+#[test]
+#[should_panic(expected = "Pair type mismatch")]
+fn test_migrated_pool_type_lp() {
+    let mut suite = SuiteBuilder::default()
+        .with_expected_pair_type(astroport::factory::PairType::Xyk {})
+        .build();
+
+    // fund pool with balanced amounts of underlying tokens
+    let token_a_amt = Uint128::new(1000);
+    let token_b_amt = Uint128::new(10000);
+    suite.provide_manual_liquidity("alice".to_string(), token_a_amt, token_b_amt);
+
+    // fund LP contract with some tokens to provide liquidity with
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_A_DENOM.to_string(),
+        token_a_amt,
+    );
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_B_DENOM.to_string(),
+        token_b_amt,
+    );
+
+    suite.tick();
+}
+
+#[test]
+#[should_panic(expected = "Price range error")]
+fn test_lp_not_within_price_range_denom_a_dominant() {
+    let mut suite = SuiteBuilder::default()
+        .build();
+
+    // fund pool with 10:1 ratio of token a to b.
+    // Liquid Pooler is configured to expect 1:10 ratio.
+    // pool balances: [10000, 1000]
+    suite.provide_manual_liquidity("alice".to_string(), Uint128::new(10000), Uint128::new(1000));
+
+    let token_a_amt = Uint128::new(1000);
+    let token_b_amt = Uint128::new(10000);
+    // fund LP contract with some tokens to provide liquidity with
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_A_DENOM.to_string(),
+        token_a_amt,
+    );
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_B_DENOM.to_string(),
+        token_b_amt,
+    );
+    suite.tick();
+}
+
+#[test]
+#[should_panic(expected = "Price range error")]
+fn test_lp_not_within_price_range_denom_b_dominant() {
+    let mut suite = SuiteBuilder::default()
+        .build();
+
+    // fund pool with 1:20 ratio of token a to b.
+    // Liquid Pooler is configured to expect 1:10 ratio.
+    // pool balances: [1000, 20000]
+    suite.provide_manual_liquidity("alice".to_string(), Uint128::new(1000), Uint128::new(20000));
+
+    let token_a_amt = Uint128::new(1000);
+    let token_b_amt = Uint128::new(10000);
+    // fund LP contract with some tokens to provide liquidity with
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_A_DENOM.to_string(),
+        token_a_amt,
+    );
+    suite.mint_coins_to_addr(
+        suite.liquid_pooler.1.to_string(),
+        TOKEN_B_DENOM.to_string(),
+        token_b_amt,
+    );
+    suite.tick();
+
+}

--- a/contracts/two-party-pol-covenant/Cargo.toml
+++ b/contracts/two-party-pol-covenant/Cargo.toml
@@ -48,6 +48,7 @@ covenant-ibc-forwarder = { workspace = true, features = ["library"] }
 covenant-interchain-router = { workspace = true, features = ["library"] }
 covenant-two-party-pol-holder = { workspace = true, features = ["library"] }
 covenant-astroport-liquid-pooler = { workspace = true, features = ["library"] }
+astroport = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test   = { workspace = true }

--- a/contracts/two-party-pol-covenant/Cargo.toml
+++ b/contracts/two-party-pol-covenant/Cargo.toml
@@ -47,6 +47,7 @@ covenant-utils = { workspace = true }
 covenant-ibc-forwarder = { workspace = true, features = ["library"] }
 covenant-interchain-router = { workspace = true, features = ["library"] }
 covenant-two-party-pol-holder = { workspace = true, features = ["library"] }
+covenant-astroport-liquid-pooler = { workspace = true, features = ["library"] }
 
 [dev-dependencies]
 cw-multi-test   = { workspace = true }

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -127,6 +127,7 @@ pub fn instantiate(
         code_id: msg.contract_codes.liquid_pooler_code,
         expected_pool_ratio: msg.expected_pool_ratio,
         acceptable_pool_ratio_delta: msg.acceptable_pool_ratio_delta,
+        pair_type: msg.pool_pair_type,
     };
 
     PRESET_CLOCK_FIELDS.save(deps.storage, &preset_clock_fields)?;

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -119,6 +119,8 @@ pub fn instantiate(
         },
         label: format!("{}_liquid_pooler", msg.label),
         code_id: msg.contract_codes.liquid_pooler_code,
+        expected_pool_ratio: msg.expected_pool_ratio,
+        acceptable_pool_ratio_delta: msg.acceptable_pool_ratio_delta,
     };
 
     PRESET_CLOCK_FIELDS.save(deps.storage, &preset_clock_fields)?;

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -266,13 +266,11 @@ pub fn handle_party_b_interchain_router_reply(
 
             let clock_address = COVENANT_CLOCK_ADDR.load(deps.storage)?.to_string();
             let pool_address = PRESET_HOLDER_FIELDS.load(deps.storage)?.pool_address.to_string();
-            let holder_address = "replace".to_string();
             let preset_liquid_pooler_fields = PRESET_LIQUID_POOLER_FIELDS.load(deps.storage)?;
 
             let instantiate_msg = preset_liquid_pooler_fields.to_instantiate_msg(
                 pool_address,
                 clock_address,
-                holder_address
             );
 
             let liquid_pooler_inst_tx = CosmosMsg::Wasm(WasmMsg::Instantiate {

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -1,3 +1,4 @@
+use astroport::factory::PairType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128, Uint64, Coin, Decimal};
 use covenant_two_party_pol_holder::msg::RagequitConfig;
@@ -24,6 +25,7 @@ pub struct InstantiateMsg {
     pub party_b_share: Uint64,
     pub expected_pool_ratio: Decimal,
     pub acceptable_pool_ratio_delta: Decimal,
+    pub pool_pair_type: PairType,
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -51,6 +51,7 @@ pub struct CovenantContractCodeIds {
     pub holder_code: u64,
     pub clock_code: u64,
     pub router_code: u64,
+    pub liquid_pooler_code: u64,
 }
 
 #[cw_serde]
@@ -107,6 +108,8 @@ pub enum QueryMsg {
     IbcForwarderAddress { party: String },
     #[returns(Addr)]
     InterchainRouterAddress { party: String }, 
+    #[returns(Addr)]
+    LiquidPoolerAddress {},
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Uint128, Uint64, Coin};
+use cosmwasm_std::{Addr, Uint128, Uint64, Coin, Decimal};
 use covenant_two_party_pol_holder::msg::RagequitConfig;
 use covenant_utils::ExpiryConfig;
 use neutron_sdk::bindings::msg::IbcFee;
@@ -22,7 +22,8 @@ pub struct InstantiateMsg {
     pub deposit_deadline: Option<ExpiryConfig>,
     pub party_a_share: Uint64,
     pub party_b_share: Uint64,
-    // TODO: lper instantiation fields
+    pub expected_pool_ratio: Decimal,
+    pub acceptable_pool_ratio_delta: Decimal,
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-covenant/src/state.rs
+++ b/contracts/two-party-pol-covenant/src/state.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::Addr;
+use covenant_astroport_liquid_pooler::msg::PresetAstroLiquidPoolerFields;
 use covenant_clock::msg::PresetClockFields;
 use covenant_ibc_forwarder::msg::PresetIbcForwarderFields;
 
@@ -17,6 +18,7 @@ pub const PRESET_PARTY_A_ROUTER_FIELDS: Item<PresetInterchainRouterFields> =
     Item::new("preset_party_a_router_fields");
 pub const PRESET_PARTY_B_ROUTER_FIELDS: Item<PresetInterchainRouterFields> =
     Item::new("preset_party_b_router_fields");
+pub const PRESET_LIQUID_POOLER_FIELDS: Item<PresetAstroLiquidPoolerFields> = Item::new("preset_lp_fields");
 
 pub const COVENANT_CLOCK_ADDR: Item<Addr> = Item::new("covenant_clock_addr");
 pub const COVENANT_POL_HOLDER_ADDR: Item<Addr> = Item::new("covenant_two_party_pol_holder_addr");
@@ -24,3 +26,4 @@ pub const PARTY_A_IBC_FORWARDER_ADDR: Item<Addr> = Item::new("party_a_ibc_forwar
 pub const PARTY_B_IBC_FORWARDER_ADDR: Item<Addr> = Item::new("party_b_ibc_forwarder_addr");
 pub const PARTY_A_ROUTER_ADDR: Item<Addr> = Item::new("party_a_router_addr");
 pub const PARTY_B_ROUTER_ADDR: Item<Addr> = Item::new("party_b_router_addr");
+pub const LIQUID_POOLER_ADDR: Item<Addr> = Item::new("liquid_pooler_addr");

--- a/two-party-pol-covenant/justfile
+++ b/two-party-pol-covenant/justfile
@@ -29,6 +29,7 @@ simtest: optimize
         mv ./../artifacts/covenant_interchain_router-aarch64.wasm ./../artifacts/covenant_interchain_router.wasm && \
         mv ./../artifacts/covenant_clock-aarch64.wasm ./../artifacts/covenant_clock.wasm && \
         mv ./../artifacts/covenant_two_party_pol_holder-aarch64.wasm ./../artifacts/covenant_two_party_pol_holder.wasm && \
+        mv ./../artifacts/covenant_astroport_liquid_pooler-aarch64.wasm ./../artifacts/covenant_liquid_pooler.wasm && \
         mv ./../artifacts/covenant_two_party_pol-aarch64.wasm ./../artifacts/covenant_two_party_pol.wasm \
     ;fi
 

--- a/two-party-pol-covenant/justfile
+++ b/two-party-pol-covenant/justfile
@@ -34,6 +34,7 @@ simtest: optimize
     ;fi
 
     mkdir -p tests/interchaintest/wasms
+    cp ./astroport/*.wasm ./../artifacts
 
     cp -R ./../artifacts/*.wasm tests/interchaintest/wasms
 

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -799,6 +799,9 @@ func TestTwoPartyPol(t *testing.T) {
 			}
 
 			poolAddress := stableswapAddress
+			pairType := PairType{
+				Stable: struct{}{},
+			}
 
 			covenantMsg := CovenantInstantiateMsg{
 				Label:                    "two-party-pol-covenant",
@@ -815,6 +818,7 @@ func TestTwoPartyPol(t *testing.T) {
 				PartyBShare:              "50",
 				ExpectedPoolRatio:        "0.1",
 				AcceptablePoolRatioDelta: "0.09",
+				PairType:                 pairType,
 			}
 			str, err := json.Marshal(covenantMsg)
 			require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -449,18 +449,20 @@ func TestTwoPartyPol(t *testing.T) {
 			}
 
 			covenantMsg := CovenantInstantiateMsg{
-				Label:           "two-party-pol-covenant",
-				Timeouts:        timeouts,
-				PresetIbcFee:    presetIbcFee,
-				ContractCodeIds: codeIds,
-				LockupConfig:    lockupConfig,
-				PartyAConfig:    partyAConfig,
-				PartyBConfig:    partyBConfig,
-				PoolAddress:     poolAddress,
-				RagequitConfig:  &ragequitConfig,
-				DepositDeadline: &depositDeadline,
-				PartyAShare:     "50",
-				PartyBShare:     "50",
+				Label:                    "two-party-pol-covenant",
+				Timeouts:                 timeouts,
+				PresetIbcFee:             presetIbcFee,
+				ContractCodeIds:          codeIds,
+				LockupConfig:             lockupConfig,
+				PartyAConfig:             partyAConfig,
+				PartyBConfig:             partyBConfig,
+				PoolAddress:              poolAddress,
+				RagequitConfig:           &ragequitConfig,
+				DepositDeadline:          &depositDeadline,
+				PartyAShare:              "50",
+				PartyBShare:              "50",
+				ExpectedPoolRatio:        "0.5",
+				AcceptablePoolRatioDelta: "0.5",
 			}
 			str, err := json.Marshal(covenantMsg)
 			require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -1098,11 +1098,16 @@ func TestTwoPartyPol(t *testing.T) {
 					require.NoError(t, err, "failed to query holder osmo bal")
 					holderAtomBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronAtomIbcDenom)
 					require.NoError(t, err, "failed to query holder atom bal")
+					liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err, "failed to query liquidPooler osmo bal")
+					liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
+					require.NoError(t, err, "failed to query liquidPooler atom bal")
 					println("holder atom bal: ", holderAtomBal)
 					println("holder osmo bal: ", holderOsmoBal)
 
-					if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) {
-						println("\nholder received atom & osmo\n")
+					if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) ||
+						liquidPoolerAtomBal == int64(atomContributionAmount) && liquidPoolerOsmoBal == int64(osmoContributionAmount) {
+						println("\nholder/liquidpooler received atom & osmo\n")
 						break
 					} else {
 						tickClock()
@@ -1148,7 +1153,7 @@ func TestTwoPartyPol(t *testing.T) {
 			})
 
 			t.Run("tick until routers route the funds after POL expires", func(t *testing.T) {
-
+				// todo
 			})
 		})
 	})

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -120,3 +120,175 @@ type LiquidPoolerQuery struct {
 type CovenantAddressQueryResponse struct {
 	Data string `json:"data"`
 }
+
+// astroport stableswap
+type StableswapInstantiateMsg struct {
+	TokenCodeId uint64      `json:"token_code_id"`
+	FactoryAddr string      `json:"factory_addr"`
+	AssetInfos  []AssetInfo `json:"asset_infos"`
+	InitParams  []byte      `json:"init_params"`
+}
+
+type AssetInfo struct {
+	Token       *Token       `json:"token,omitempty"`
+	NativeToken *NativeToken `json:"native_token,omitempty"`
+}
+
+type StablePoolParams struct {
+	Amp   uint64  `json:"amp"`
+	Owner *string `json:"owner"`
+}
+
+type Token struct {
+	ContractAddr string `json:"contract_addr"`
+}
+
+type NativeToken struct {
+	Denom string `json:"denom"`
+}
+
+type CwCoin struct {
+	Denom  string `json:"denom"`
+	Amount uint64 `json:"amount"`
+}
+
+// astroport factory
+type FactoryInstantiateMsg struct {
+	PairConfigs         []PairConfig `json:"pair_configs"`
+	TokenCodeId         uint64       `json:"token_code_id"`
+	FeeAddress          *string      `json:"fee_address"`
+	GeneratorAddress    *string      `json:"generator_address"`
+	Owner               string       `json:"owner"`
+	WhitelistCodeId     uint64       `json:"whitelist_code_id"`
+	CoinRegistryAddress string       `json:"coin_registry_address"`
+}
+
+type PairConfig struct {
+	CodeId              uint64   `json:"code_id"`
+	PairType            PairType `json:"pair_type"`
+	TotalFeeBps         uint64   `json:"total_fee_bps"`
+	MakerFeeBps         uint64   `json:"maker_fee_bps"`
+	IsDisabled          bool     `json:"is_disabled"`
+	IsGeneratorDisabled bool     `json:"is_generator_disabled"`
+}
+
+type PairType struct {
+	// Xyk    struct{} `json:"xyk,omitempty"`
+	Stable struct{} `json:"stable,omitempty"`
+	// Custom struct{} `json:"custom,omitempty"`
+}
+
+// astroport native coin registry
+
+type NativeCoinRegistryInstantiateMsg struct {
+	Owner string `json:"owner"`
+}
+
+type AddExecuteMsg struct {
+	Add Add `json:"add"`
+}
+
+type Add struct {
+	NativeCoins []NativeCoin `json:"native_coins"`
+}
+
+type NativeCoin struct {
+	Name  string `json:"name"`
+	Value uint8  `json:"value"`
+}
+
+// Add { native_coins: Vec<(String, u8)> },
+
+// astroport native token
+type NativeTokenInstantiateMsg struct {
+	Name            string                    `json:"name"`
+	Symbol          string                    `json:"symbol"`
+	Decimals        uint8                     `json:"decimals"`
+	InitialBalances []Cw20Coin                `json:"initial_balances"`
+	Mint            *MinterResponse           `json:"mint"`
+	Marketing       *InstantiateMarketingInfo `json:"marketing"`
+}
+
+type Cw20Coin struct {
+	Address string `json:"address"`
+	Amount  uint64 `json:"amount"`
+}
+
+type MinterResponse struct {
+	Minter string  `json:"minter"`
+	Cap    *uint64 `json:"cap,omitempty"`
+}
+
+type InstantiateMarketingInfo struct {
+	Project     string `json:"project"`
+	Description string `json:"description"`
+	Marketing   string `json:"marketing"`
+	Logo        Logo   `json:"logo"`
+}
+
+type Logo struct {
+	Url string `json:"url"`
+}
+
+// astroport whitelist
+type WhitelistInstantiateMsg struct {
+	Admins  []string `json:"admins"`
+	Mutable bool     `json:"mutable"`
+}
+
+type ProvideLiqudityMsg struct {
+	ProvideLiquidity ProvideLiquidityStruct `json:"provide_liquidity"`
+}
+
+type ProvideLiquidityStruct struct {
+	Assets            []AstroportAsset `json:"assets"`
+	SlippageTolerance string           `json:"slippage_tolerance"`
+	AutoStake         bool             `json:"auto_stake"`
+	Receiver          string           `json:"receiver"`
+}
+
+// factory
+
+type FactoryPairResponse struct {
+	Data PairInfo `json:"data"`
+}
+
+type LpPositionQueryResponse struct {
+	Data string `json:"data"`
+}
+
+type AstroportAsset struct {
+	Info   AssetInfo `json:"info"`
+	Amount string    `json:"amount"`
+}
+
+type LpPositionQuery struct{}
+
+type PairInfo struct {
+	LiquidityToken string      `json:"liquidity_token"`
+	ContractAddr   string      `json:"contract_addr"`
+	PairType       PairType    `json:"pair_type"`
+	AssetInfos     []AssetInfo `json:"asset_infos"`
+}
+
+type LPPositionQuery struct {
+	LpPosition LpPositionQuery `json:"lp_position"`
+}
+
+type Pair struct {
+	AssetInfos []AssetInfo `json:"asset_infos"`
+}
+
+type PairQuery struct {
+	Pair Pair `json:"pair"`
+}
+
+type CreatePair struct {
+	PairType   PairType    `json:"pair_type"`
+	AssetInfos []AssetInfo `json:"asset_infos"`
+	InitParams []byte      `json:"init_params"`
+}
+
+type CreatePairMsg struct {
+	CreatePair CreatePair `json:"create_pair"`
+}

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -6,19 +6,21 @@ package ibc_test
 
 // ----- Covenant Instantiation ------
 type CovenantInstantiateMsg struct {
-	Label           string              `json:"label"`
-	Timeouts        Timeouts            `json:"timeouts"`
-	PresetIbcFee    PresetIbcFee        `json:"preset_ibc_fee"`
-	ContractCodeIds ContractCodeIds     `json:"contract_codes"`
-	TickMaxGas      string              `json:"clock_tick_max_gas,omitempty"`
-	LockupConfig    ExpiryConfig        `json:"lockup_config"`
-	PartyAConfig    CovenantPartyConfig `json:"party_a_config"`
-	PartyBConfig    CovenantPartyConfig `json:"party_b_config"`
-	PoolAddress     string              `json:"pool_address"`
-	RagequitConfig  *RagequitConfig     `json:"ragequit_config,omitempty"`
-	DepositDeadline *ExpiryConfig       `json:"deposit_deadline,omitempty"`
-	PartyAShare     string              `json:"party_a_share"`
-	PartyBShare     string              `json:"party_b_share"`
+	Label                    string              `json:"label"`
+	Timeouts                 Timeouts            `json:"timeouts"`
+	PresetIbcFee             PresetIbcFee        `json:"preset_ibc_fee"`
+	ContractCodeIds          ContractCodeIds     `json:"contract_codes"`
+	TickMaxGas               string              `json:"clock_tick_max_gas,omitempty"`
+	LockupConfig             ExpiryConfig        `json:"lockup_config"`
+	PartyAConfig             CovenantPartyConfig `json:"party_a_config"`
+	PartyBConfig             CovenantPartyConfig `json:"party_b_config"`
+	PoolAddress              string              `json:"pool_address"`
+	RagequitConfig           *RagequitConfig     `json:"ragequit_config,omitempty"`
+	DepositDeadline          *ExpiryConfig       `json:"deposit_deadline,omitempty"`
+	PartyAShare              string              `json:"party_a_share"`
+	PartyBShare              string              `json:"party_b_share"`
+	ExpectedPoolRatio        string              `json:"expected_pool_ratio"`
+	AcceptablePoolRatioDelta string              `json:"acceptable_pool_ratio_delta"`
 }
 
 type ContractCodeIds struct {

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -26,6 +26,7 @@ type ContractCodeIds struct {
 	InterchainRouterCode uint64 `json:"router_code"`
 	ClockCode            uint64 `json:"clock_code"`
 	HolderCode           uint64 `json:"holder_code"`
+	LiquidPoolerCode     uint64 `json:"liquid_pooler_code"`
 }
 
 type Timeouts struct {
@@ -110,7 +111,10 @@ type InterchainRouterQuery struct {
 type IbcForwarderQuery struct {
 	Party Party `json:"ibc_forwarder_address"`
 }
-
+type LiquidPoolerAddress struct{}
+type LiquidPoolerQuery struct {
+	LiquidPoolerAddress LiquidPoolerAddress `json:"liquid_pooler_address"`
+}
 type CovenantAddressQueryResponse struct {
 	Data string `json:"data"`
 }

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -292,3 +292,27 @@ type CreatePair struct {
 type CreatePairMsg struct {
 	CreatePair CreatePair `json:"create_pair"`
 }
+
+type BalanceResponse struct {
+	Balance string `json:"balance"`
+}
+
+type Cw20BalanceResponse struct {
+	Data BalanceResponse `json:"data"`
+}
+
+type AllAccountsResponse struct {
+	Data []string `json:"all_accounts_response"`
+}
+
+type Cw20QueryMsg struct {
+	Balance Balance `json:"balance"`
+	// AllAccounts *AllAccounts `json:"all_accounts"`
+}
+
+type AllAccounts struct {
+}
+
+type Balance struct {
+	Address string `json:"address"`
+}

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -21,6 +21,7 @@ type CovenantInstantiateMsg struct {
 	PartyBShare              string              `json:"party_b_share"`
 	ExpectedPoolRatio        string              `json:"expected_pool_ratio"`
 	AcceptablePoolRatioDelta string              `json:"acceptable_pool_ratio_delta"`
+	PairType                 PairType            `json:"pool_pair_type"`
 }
 
 type ContractCodeIds struct {


### PR DESCRIPTION
attempt at #118 

Instead of using the notion of native/liquid staked tokens, this liquid pooler deals with denom `a` and denom `b`.

because of no instantiate2 availability, after instantiation this contract expects a migration config update that would set the holder address. it's necessary for directing the LP tokens when providing liquidity to the pool. this is done by the covenant itself.

merging into the two-party-pol branch as it is blocked by this. I expect changes in design on this one so no unit tests for now. Only happy path is included in the interchaintests.

