### PR TITLE
two party pol denom config rework

### DIFF
--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -26,11 +26,15 @@ jobs:
               target: wasm32-unknown-unknown
               override: true
 
-          - name: install nodejs
-            run: |
-              sudo apt install nodejs
-              node -v
-              sudo apt install npm
+          # - name: install nodejs
+          #   run: |
+          #     sudo apt install nodejs
+          #     node -v
+          #     sudo apt install npm
+          - uses: actions/setup-node@v3
+            with:
+              node-version: 18
+          - run: npm install
 
           - name: install tar for cache
             run: |

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -26,15 +26,9 @@ jobs:
               target: wasm32-unknown-unknown
               override: true
 
-          # - name: install nodejs
-          #   run: |
-          #     sudo apt install nodejs
-          #     node -v
-          #     sudo apt install npm
           - uses: actions/setup-node@v3
             with:
               node-version: 18
-          - run: npm install
 
           - name: install tar for cache
             run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,118 +21,17 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "astroport"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b863a982595743e181f89540d7aaeda35c60b6b5cac9c36c9be30cf11a5ece"
+checksum = "8b9d984e989728f0b0262c24d2159d60c2b82719f6c85db6aee63b91bbdccdf4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
- "cw20 0.15.1",
+ "cw20",
  "itertools 0.10.5",
  "uint",
-]
-
-[[package]]
-name = "astroport"
-version = "3.6.1"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "astroport-circular-buffer",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
- "cw20 0.15.1",
- "cw3",
- "itertools 0.10.5",
- "uint",
-]
-
-[[package]]
-name = "astroport-circular-buffer"
-version = "0.1.0"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "thiserror",
-]
-
-[[package]]
-name = "astroport-factory"
-version = "1.6.0"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "astroport 3.6.1",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
- "cw2 0.15.1",
- "itertools 0.10.5",
- "protobuf 2.28.0",
- "thiserror",
-]
-
-[[package]]
-name = "astroport-native-coin-registry"
-version = "1.0.1"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "astroport 3.6.1",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.15.1",
- "cw2 0.15.1",
- "thiserror",
-]
-
-[[package]]
-name = "astroport-pair-stable"
-version = "3.3.0"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "astroport 3.6.1",
- "astroport-circular-buffer",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "itertools 0.10.5",
- "thiserror",
-]
-
-[[package]]
-name = "astroport-token"
-version = "1.1.1"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "astroport 3.6.1",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "cw20-base",
- "snafu",
-]
-
-[[package]]
-name = "astroport-whitelist"
-version = "1.0.1"
-source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
-dependencies = [
- "astroport 3.6.1",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw1-whitelist 0.15.1",
- "cw2 0.15.1",
- "thiserror",
 ]
 
 [[package]]
@@ -320,25 +219,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-storage"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2b4ae72a03e8f56c85df59d172d51d2d7dc9cec6e2bc811e3fb60c588032a4"
-dependencies = [
- "cosmwasm-std",
- "serde",
-]
-
-[[package]]
 name = "covenant-astroport-liquid-pooler"
 version = "1.0.0"
 dependencies = [
- "astroport 2.9.0",
- "astroport-factory",
- "astroport-native-coin-registry",
- "astroport-pair-stable",
- "astroport-token",
- "astroport-whitelist",
+ "astroport",
  "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -347,11 +231,11 @@ dependencies = [
  "covenant-two-party-pol-holder",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
- "cw1-whitelist 1.1.1",
+ "cw1-whitelist",
  "cw2 1.1.1",
- "cw20 0.15.1",
+ "cw20",
  "neutron-sdk",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -405,7 +289,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -431,7 +315,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -477,7 +361,7 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw2 1.1.1",
  "neutron-sdk",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -489,7 +373,7 @@ name = "covenant-swap"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport",
  "bech32",
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
@@ -507,7 +391,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -537,7 +421,7 @@ name = "covenant-two-party-pol"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport",
  "base64 0.13.1",
  "bech32",
  "cosmos-sdk-proto 0.14.0",
@@ -556,7 +440,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -569,7 +453,7 @@ name = "covenant-two-party-pol-holder"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport",
  "cosmwasm-schema",
  "cosmwasm-std",
  "covenant-macros",
@@ -578,7 +462,7 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.2",
  "cw2 1.1.1",
- "cw20 0.15.1",
+ "cw20",
  "schemars",
  "serde",
  "thiserror",
@@ -739,18 +623,6 @@ dependencies = [
 
 [[package]]
 name = "cw1"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe0783ec4210ba4e0cdfed9874802f469c6db0880f742ad427cb950e940b21c"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw1"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd87b521055960569f562a143078c93031d5e8780d9520936cc97f8aa2f1101"
@@ -763,23 +635,6 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233dd13f61495f1336da57c8bdca0536fa9f8dd59c12d2bbfc59928ea580e478"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
- "cw1 0.15.1",
- "cw2 0.15.1",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw1-whitelist"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c12f6e7859ad758c95e7bcd7ac59419d550b41e4e35bf8aac021070a686abc"
@@ -788,7 +643,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.2",
- "cw1 1.1.1",
+ "cw1",
  "cw2 1.1.1",
  "schemars",
  "serde",
@@ -833,52 +688,6 @@ dependencies = [
  "cw-utils 0.15.1",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw20"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786e9da5e937f473cecd2463e81384c1af65d0f6398bbd851be7655487c55492"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils 1.0.2",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw20-base"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0909c56d0c14601fbdc69382189799482799dcad87587926aec1f3aa321abc41"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw3"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d056ec33ec146554aa1d16c9535763341db75589a47743c006c377e62b54034"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils 1.0.2",
- "cw20 1.1.1",
- "schemars",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -932,12 +741,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -1199,7 +1002,7 @@ dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "protobuf 3.3.0",
+ "protobuf",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.0",
@@ -1367,15 +1170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
  "prost 0.12.1",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -1628,27 +1422,6 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "snafu"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "covenant-macros",
+ "covenant-utils",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,11 @@ dependencies = [
 name = "covenant-utils"
 version = "0.0.1"
 dependencies = [
+ "astroport 2.9.1",
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw20 0.15.1",
  "neutron-sdk",
  "prost 0.11.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,110 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
- "cw20",
+ "cw20 0.15.1",
  "itertools 0.10.5",
  "uint",
+]
+
+[[package]]
+name = "astroport"
+version = "3.6.1"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "astroport-circular-buffer",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.2",
+ "cw20 0.15.1",
+ "cw3",
+ "itertools 0.10.5",
+ "uint",
+]
+
+[[package]]
+name = "astroport-circular-buffer"
+version = "0.1.0"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-factory"
+version = "1.6.0"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "astroport 3.6.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.2",
+ "cw2 0.15.1",
+ "itertools 0.10.5",
+ "protobuf 2.28.0",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-native-coin-registry"
+version = "1.0.1"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "astroport 3.6.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-pair-stable"
+version = "3.3.0"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "astroport 3.6.1",
+ "astroport-circular-buffer",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.2",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "itertools 0.10.5",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-token"
+version = "1.1.1"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "astroport 3.6.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "cw20-base",
+ "snafu",
+]
+
+[[package]]
+name = "astroport-whitelist"
+version = "1.0.1"
+source = "git+https://github.com/astroport-fi/astroport-core.git#3b7c0c5681f6b287e61cadc8045431e11d2fbae0"
+dependencies = [
+ "astroport 3.6.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw1-whitelist 0.15.1",
+ "cw2 0.15.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -219,10 +320,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-storage"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b4ae72a03e8f56c85df59d172d51d2d7dc9cec6e2bc811e3fb60c588032a4"
+dependencies = [
+ "cosmwasm-std",
+ "serde",
+]
+
+[[package]]
 name = "covenant-astroport-liquid-pooler"
 version = "1.0.0"
 dependencies = [
- "astroport",
+ "astroport 2.9.1",
+ "astroport-factory",
+ "astroport-native-coin-registry",
+ "astroport-pair-stable",
+ "astroport-token",
+ "astroport-whitelist",
  "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -231,11 +347,11 @@ dependencies = [
  "covenant-two-party-pol-holder",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
- "cw1-whitelist",
+ "cw1-whitelist 1.1.1",
  "cw2 1.1.1",
- "cw20",
+ "cw20 0.15.1",
  "neutron-sdk",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -289,7 +405,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -315,7 +431,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -361,7 +477,7 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw2 1.1.1",
  "neutron-sdk",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -373,7 +489,7 @@ name = "covenant-swap"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport",
+ "astroport 2.9.1",
  "bech32",
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
@@ -391,7 +507,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -421,7 +537,7 @@ name = "covenant-two-party-pol"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport",
+ "astroport 2.9.1",
  "base64 0.13.1",
  "bech32",
  "cosmos-sdk-proto 0.14.0",
@@ -440,7 +556,7 @@ dependencies = [
  "neutron-sdk",
  "prost 0.11.9",
  "prost-types 0.11.9",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -453,7 +569,7 @@ name = "covenant-two-party-pol-holder"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "covenant-macros",
@@ -462,7 +578,7 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.2",
  "cw2 1.1.1",
- "cw20",
+ "cw20 0.15.1",
  "schemars",
  "serde",
  "thiserror",
@@ -623,6 +739,18 @@ dependencies = [
 
 [[package]]
 name = "cw1"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe0783ec4210ba4e0cdfed9874802f469c6db0880f742ad427cb950e940b21c"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw1"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd87b521055960569f562a143078c93031d5e8780d9520936cc97f8aa2f1101"
@@ -635,6 +763,23 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233dd13f61495f1336da57c8bdca0536fa9f8dd59c12d2bbfc59928ea580e478"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 0.15.1",
+ "cw1 0.15.1",
+ "cw2 0.15.1",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw1-whitelist"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c12f6e7859ad758c95e7bcd7ac59419d550b41e4e35bf8aac021070a686abc"
@@ -643,7 +788,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.2",
- "cw1",
+ "cw1 1.1.1",
  "cw2 1.1.1",
  "schemars",
  "serde",
@@ -688,6 +833,52 @@ dependencies = [
  "cw-utils 0.15.1",
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "cw20"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786e9da5e937f473cecd2463e81384c1af65d0f6398bbd851be7655487c55492"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.2",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw20-base"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909c56d0c14601fbdc69382189799482799dcad87587926aec1f3aa321abc41"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 0.15.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw3"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d056ec33ec146554aa1d16c9535763341db75589a47743c006c377e62b54034"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.2",
+ "cw20 1.1.1",
+ "schemars",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -741,6 +932,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -1002,7 +1199,7 @@ dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "protobuf",
+ "protobuf 3.3.0",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.0",
@@ -1170,6 +1367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
  "prost 0.12.1",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -1422,6 +1628,27 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "ecdsa"
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "neutron-sdk"
@@ -1151,7 +1151,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1304,9 +1304,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -1349,13 +1349,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1478,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1540,7 +1540,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,8 @@ syn               = "1"
 cw-multi-test   = "0.16.2"
 anyhow          = { version = "1.0.51" }
 cw1-whitelist = "1.1.0"
+astroport-token = {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-whitelist = {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-factory =  {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-native-coin-registry = {git = "https://github.com/astroport-fi/astroport-core.git"}
+astroport-pair-stable = {git = "https://github.com/astroport-fi/astroport-core.git"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,4 @@ syn               = "1"
 # dev-dependencies
 cw-multi-test   = "0.16.2"
 anyhow          = { version = "1.0.51" }
-astroport-token = {git = "https://github.com/astroport-fi/astroport-core.git"}
-astroport-whitelist = {git = "https://github.com/astroport-fi/astroport-core.git"}
-astroport-factory =  {git = "https://github.com/astroport-fi/astroport-core.git"}
-astroport-native-coin-registry = {git = "https://github.com/astroport-fi/astroport-core.git"}
-astroport-pair-stable = {git = "https://github.com/astroport-fi/astroport-core.git"}
 cw1-whitelist = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ edition      = "2021"
 license      = "BSD-3"
 version      = "1.0.0"
 repository = "https://github.com/timewave-computer/covenants"
-
 rust-version = "1.66"
 
 [profile.release]

--- a/contracts/astroport-liquid-pooler/Cargo.toml
+++ b/contracts/astroport-liquid-pooler/Cargo.toml
@@ -47,10 +47,6 @@ cw20             = { workspace = true }
 # dev-dependencies
 [dev-dependencies]
 cw-multi-test = { workspace = true }
-astroport-token = { workspace = true }
-astroport-whitelist = { workspace = true }
-astroport-factory = { workspace = true }
-astroport-native-coin-registry = { workspace = true }
-astroport-pair-stable = { workspace = true }
+astroport = { workspace = true }
 cw1-whitelist = { workspace = true }
 covenant-two-party-pol-holder = { workspace = true }

--- a/contracts/astroport-liquid-pooler/Cargo.toml
+++ b/contracts/astroport-liquid-pooler/Cargo.toml
@@ -50,3 +50,8 @@ cw-multi-test = { workspace = true }
 astroport = { workspace = true }
 cw1-whitelist = { workspace = true }
 covenant-two-party-pol-holder = { workspace = true }
+astroport-token = { workspace = true }
+astroport-whitelist = { workspace = true }
+astroport-factory = { workspace = true }
+astroport-native-coin-registry = { workspace = true }
+astroport-pair-stable = { workspace = true }

--- a/contracts/astroport-liquid-pooler/src/suite_test/suite.rs
+++ b/contracts/astroport-liquid-pooler/src/suite_test/suite.rs
@@ -39,7 +39,7 @@ fn astro_token() -> Box<dyn Contract<Empty>> {
 
 fn astro_whitelist() -> Box<dyn Contract<Empty>> {
     Box::new(ContractWrapper::new(
-        astroport_whitelist::contract::instantiate,
+        astroport_whitelist::contract::execute,
         astroport_whitelist::contract::instantiate,
         astroport_whitelist::contract::query,
     ))

--- a/contracts/ibc-forwarder/src/contract.rs
+++ b/contracts/ibc-forwarder/src/contract.rs
@@ -121,9 +121,9 @@ fn try_forward_funds(env: Env, mut deps: ExecuteDeps) -> NeutronResult<Response<
 
     // if query returns None, then we error and wait
     let Some(deposit_address) = deposit_address_query else {
-        return Err(NeutronError::Std(
-            StdError::not_found("Next contract is not ready for receiving the funds yet")
-        ))
+        return Err(NeutronError::Std(StdError::not_found(
+            "Next contract is not ready for receiving the funds yet",
+        )));
     };
 
     let port_id = get_port_id(env.contract.address.as_str(), INTERCHAIN_ACCOUNT_ID);
@@ -287,7 +287,7 @@ fn sudo_open_ack(
 
     // get the parsed OpenAckVersion or return an error if we fail
     let Ok(parsed_version) = parsed_version else {
-        return Err(StdError::generic_err("Can't parse counterparty_version"))
+        return Err(StdError::generic_err("Can't parse counterparty_version"));
     };
 
     // Update the storage record associated with the interchain account.

--- a/contracts/native-splitter/src/contract.rs
+++ b/contracts/native-splitter/src/contract.rs
@@ -320,7 +320,7 @@ fn sudo_open_ack(
 
     // get the parsed OpenAckVersion or return an error if we fail
     let Ok(parsed_version) = parsed_version else {
-        return Err(StdError::generic_err("Can't parse counterparty_version"))
+        return Err(StdError::generic_err("Can't parse counterparty_version"));
     };
 
     // Update the storage record associated with the interchain account.

--- a/contracts/swap-holder/src/contract.rs
+++ b/contracts/swap-holder/src/contract.rs
@@ -127,9 +127,9 @@ fn try_forward(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
 
     // if query returns None, then we error and wait
     let Some(deposit_address) = deposit_address_query else {
-        return Err(ContractError::Std(
-            StdError::not_found("Next contract is not ready for receiving the funds yet")
-        ))
+        return Err(ContractError::Std(StdError::not_found(
+            "Next contract is not ready for receiving the funds yet",
+        )));
     };
 
     let multi_send_msg = CosmosMsg::Bank(BankMsg::Send {

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -326,20 +326,12 @@ pub fn handle_liquid_pooler_reply_id(
             let clock_addr = COVENANT_CLOCK_ADDR.load(deps.storage)?;
             let party_a_router = PARTY_A_ROUTER_ADDR.load(deps.storage)?;
 
-            let instantiate_msg = match preset_holder_fields.clone().to_instantiate_msg(
+            let instantiate_msg = preset_holder_fields.clone().to_instantiate_msg(
                 clock_addr.to_string(),
                 liquid_pooler.to_string(),
                 party_a_router.as_str(),
                 party_b_router.as_str(),
-            ) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    return Err(ContractError::ContractInstantiationError {
-                        contract: "holder".to_string(),
-                        err: ParseReplyError::SubMsgFailure(e.to_string()),
-                    })
-                }
-            };
+            )?;
 
             let holder_instantiate_tx = CosmosMsg::Wasm(WasmMsg::Instantiate {
                 admin: Some(env.contract.address.to_string()),
@@ -352,6 +344,7 @@ pub fn handle_liquid_pooler_reply_id(
             Ok(Response::default()
                 .add_attribute("method", "handle_liquid_pooler_reply")
                 .add_attribute("liquid_pooler_addr", liquid_pooler)
+                .add_attribute("holder_instantiate_tx", to_binary(&holder_instantiate_tx)?.to_string())
                 .add_submessage(SubMsg::reply_always(holder_instantiate_tx, HOLDER_REPLY_ID)))
         }
         Err(err) => Err(ContractError::ContractInstantiationError {

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -344,7 +344,10 @@ pub fn handle_liquid_pooler_reply_id(
             Ok(Response::default()
                 .add_attribute("method", "handle_liquid_pooler_reply")
                 .add_attribute("liquid_pooler_addr", liquid_pooler)
-                .add_attribute("holder_instantiate_tx", to_binary(&holder_instantiate_tx)?.to_string())
+                .add_attribute(
+                    "holder_instantiate_tx",
+                    to_binary(&holder_instantiate_tx)?.to_string(),
+                )
                 .add_submessage(SubMsg::reply_always(holder_instantiate_tx, HOLDER_REPLY_ID)))
         }
         Err(err) => Err(ContractError::ContractInstantiationError {

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -82,6 +82,7 @@ pub fn instantiate(
         label: format!("{}-holder", msg.label),
         splits: msg.splits,
         fallback_split: msg.fallback_split,
+        covenant_type: msg.covenant_type,
     };
     let preset_party_a_forwarder_fields = PresetIbcForwarderFields {
         remote_chain_connection_id: msg.party_a_config.party_chain_connection_id,

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -15,7 +15,7 @@ use covenant_two_party_pol_holder::msg::{
     PresetPolParty, PresetTwoPartyPolHolderFields, RagequitConfig,
 };
 use cw2::set_contract_version;
-use cw_utils::{parse_reply_instantiate_data, ParseReplyError};
+use cw_utils::parse_reply_instantiate_data;
 
 use crate::{
     error::ContractError,
@@ -65,7 +65,7 @@ pub fn instantiate(
                 denom: msg.party_a_config.ibc_denom.to_string(),
                 amount: msg.party_a_config.contribution.amount,
             },
-            controller_addr: msg.party_a_config.controller_addr,
+            controller_addr: msg.party_a_config.controller_addr.to_string(),
             host_addr: msg.party_a_config.host_addr,
             allocation: Decimal::from_ratio(msg.party_a_share, Uint128::new(100)),
         },
@@ -74,7 +74,7 @@ pub fn instantiate(
                 denom: msg.party_b_config.ibc_denom.to_string(),
                 amount: msg.party_b_config.contribution.amount,
             },
-            controller_addr: msg.party_b_config.controller_addr,
+            controller_addr: msg.party_b_config.controller_addr.to_string(),
             host_addr: msg.party_b_config.host_addr,
             allocation: Decimal::from_ratio(msg.party_b_share, Uint128::new(100)),
         },
@@ -109,14 +109,14 @@ pub fn instantiate(
 
     let preset_party_a_router_fields = PresetInterchainRouterFields {
         destination_chain_channel_id: msg.party_a_config.host_to_party_chain_channel_id,
-        destination_receiver_addr: msg.party_a_config.party_receiver_addr,
+        destination_receiver_addr: msg.party_a_config.controller_addr,
         ibc_transfer_timeout: msg.party_a_config.ibc_transfer_timeout,
         label: format!("{}_party_a_interchain_router", msg.label),
         code_id: msg.contract_codes.router_code,
     };
     let preset_party_b_router_fields = PresetInterchainRouterFields {
         destination_chain_channel_id: msg.party_b_config.host_to_party_chain_channel_id,
-        destination_receiver_addr: msg.party_b_config.party_receiver_addr,
+        destination_receiver_addr: msg.party_b_config.controller_addr,
         ibc_transfer_timeout: msg.party_b_config.ibc_transfer_timeout,
         label: format!("{}_party_b_interchain_router", msg.label),
         code_id: msg.contract_codes.router_code,

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -332,10 +332,12 @@ pub fn handle_liquid_pooler_reply_id(
                 party_b_router.as_str(),
             ) {
                 Ok(msg) => msg,
-                Err(e) => return Err(ContractError::ContractInstantiationError {
-                    contract: "holder".to_string(),
-                    err: ParseReplyError::SubMsgFailure(e.to_string()),
-                }),
+                Err(e) => {
+                    return Err(ContractError::ContractInstantiationError {
+                        contract: "holder".to_string(),
+                        err: ParseReplyError::SubMsgFailure(e.to_string()),
+                    })
+                }
             };
 
             let holder_instantiate_tx = CosmosMsg::Wasm(WasmMsg::Instantiate {

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -2,6 +2,7 @@ use astroport::factory::PairType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128, Uint64};
 use covenant_two_party_pol_holder::msg::RagequitConfig;
+use covenant_utils::{DenomSplit, SplitType};
 use cw_utils::Expiration;
 use neutron_sdk::bindings::msg::IbcFee;
 
@@ -26,6 +27,8 @@ pub struct InstantiateMsg {
     pub expected_pool_ratio: Decimal,
     pub acceptable_pool_ratio_delta: Decimal,
     pub pool_pair_type: PairType,
+    pub splits: Vec<DenomSplit>,
+    pub fallback_split: Option<SplitType>,
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -1,8 +1,8 @@
 use astroport::factory::PairType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128, Uint64};
-use covenant_two_party_pol_holder::msg::{RagequitConfig, CovenantType};
-use covenant_utils::{DenomSplit, SplitType, SplitConfig};
+use covenant_two_party_pol_holder::msg::{CovenantType, RagequitConfig};
+use covenant_utils::{DenomSplit, SplitConfig, SplitType};
 use cw_utils::Expiration;
 use neutron_sdk::bindings::msg::IbcFee;
 

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -2,7 +2,7 @@ use astroport::factory::PairType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128, Uint64};
 use covenant_two_party_pol_holder::msg::{RagequitConfig, CovenantType};
-use covenant_utils::{DenomSplit, SplitType};
+use covenant_utils::{DenomSplit, SplitType, SplitConfig};
 use cw_utils::Expiration;
 use neutron_sdk::bindings::msg::IbcFee;
 
@@ -29,7 +29,7 @@ pub struct InstantiateMsg {
     pub acceptable_pool_ratio_delta: Decimal,
     pub pool_pair_type: PairType,
     pub splits: Vec<DenomSplit>,
-    pub fallback_split: Option<SplitType>,
+    pub fallback_split: Option<SplitConfig>,
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -1,7 +1,7 @@
 use astroport::factory::PairType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128, Uint64};
-use covenant_two_party_pol_holder::msg::RagequitConfig;
+use covenant_two_party_pol_holder::msg::{RagequitConfig, CovenantType};
 use covenant_utils::{DenomSplit, SplitType};
 use cw_utils::Expiration;
 use neutron_sdk::bindings::msg::IbcFee;
@@ -19,6 +19,7 @@ pub struct InstantiateMsg {
     pub lockup_config: Expiration,
     pub party_a_config: CovenantPartyConfig,
     pub party_b_config: CovenantPartyConfig,
+    pub covenant_type: CovenantType,
     pub pool_address: String,
     pub ragequit_config: Option<RagequitConfig>,
     pub deposit_deadline: Expiration,

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -2,7 +2,7 @@ use astroport::factory::PairType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128, Uint64};
 use covenant_two_party_pol_holder::msg::{CovenantType, RagequitConfig};
-use covenant_utils::{DenomSplit, SplitConfig, SplitType};
+use covenant_utils::{DenomSplit, SplitConfig};
 use cw_utils::Expiration;
 use neutron_sdk::bindings::msg::IbcFee;
 

--- a/contracts/two-party-pol-covenant/src/msg.rs
+++ b/contracts/two-party-pol-covenant/src/msg.rs
@@ -34,7 +34,8 @@ pub struct InstantiateMsg {
 
 #[cw_serde]
 pub struct CovenantPartyConfig {
-    /// authorized address of the party on the controller chain
+    /// authorized address of the party on the controller
+    /// chain (final receiver)
     pub controller_addr: String,
     /// authorized address of the party on the host chain
     pub host_addr: String,
@@ -46,8 +47,6 @@ pub struct CovenantPartyConfig {
     pub party_to_host_chain_channel_id: String,
     /// channel id from host chain to the party chain
     pub host_to_party_chain_channel_id: String,
-    /// address of the receiver on destination chain
-    pub party_receiver_addr: String,
     /// connection id to the party chain
     pub party_chain_connection_id: String,
     /// timeout in seconds

--- a/contracts/two-party-pol-holder/Cargo.toml
+++ b/contracts/two-party-pol-holder/Cargo.toml
@@ -17,18 +17,19 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-covenant-macros = { workspace = true }
-cosmwasm-schema  = { workspace = true }
-cosmwasm-std     = { workspace = true }
-cw-storage-plus  = { workspace = true }
-cw2              = { workspace = true }
-thiserror        = { workspace = true }
-schemars         = { workspace = true }
-serde            = { workspace = true }
-astroport        = { workspace = true }
-cw20             = { workspace = true }
-cw-utils = { workspace = true }
+covenant-macros   = { workspace = true }
+cosmwasm-schema   = { workspace = true }
+cosmwasm-std      = { workspace = true }
+cw-storage-plus   = { workspace = true }
+cw2               = { workspace = true }
+thiserror         = { workspace = true }
+schemars          = { workspace = true }
+serde             = { workspace = true }
+astroport         = { workspace = true }
+cw20              = { workspace = true }
+cw-utils          = { workspace = true }
+covenant-utils    = { workspace = true }
 
 [dev-dependencies]
-cw-multi-test = { workspace = true }
-anyhow = { workspace = true }
+cw-multi-test   = { workspace = true }
+anyhow          = { workspace = true }

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -130,9 +130,7 @@ fn try_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Con
     // we exit early if contract is not in ragequit or expired state
     // otherwise claim process is the same
     let response: Response = match contract_state {
-        ContractState::Ragequit => {
-            Response::default().add_attribute("method", "try_claim_ragequit")
-        }
+        ContractState::Ragequit => Response::default().add_attribute("method", "try_claim_ragequit"),
         ContractState::Expired => Response::default().add_attribute("method", "try_claim_expired"),
         _ => return Err(ContractError::ClaimError {}),
     };
@@ -374,8 +372,7 @@ fn try_ragequit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
         covenant_config.authorize_sender(info.sender.to_string())?;
     let rq_denom = rq_party.contribution.denom.to_string();
     // after all validations we are ready to perform the ragequit.
-    // first we apply the ragequit penalty.
-    // TODO: here we need to reflect the ragequit penalty on all split configurations?
+    // first we apply the ragequit penalty on our split configs
     SPLIT_CONFIG_MAP.update(deps.storage, rq_denom, |mut c| -> StdResult<_> {
         match c {
             Some(mut config) => {

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -313,8 +313,7 @@ fn try_tick(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Cont
         ContractState::Complete => Ok(Response::default()
             .add_attribute("method", "tick")
             .add_attribute("contract_state", state.to_string())),
-        // ragequit and expired
-        _ => {
+        ContractState::Expired | ContractState::Ragequit => {
             let pool = POOL_ADDRESS.load(deps.storage)?;
             let lp_token_bal = query_astro_pool_token(
                 deps.querier,

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -1,9 +1,6 @@
 use std::collections::BTreeMap;
 
-use astroport::{
-    asset::Asset,
-    pair::Cw20HookMsg,
-};
+use astroport::{asset::Asset, pair::Cw20HookMsg};
 use cosmwasm_std::{
     to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo,
     Response, StdError, StdResult, Uint128, WasmMsg,

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -1,12 +1,12 @@
 use std::collections::BTreeMap;
 
 use astroport::{
-    asset::{Asset, PairInfo},
+    asset::Asset,
     pair::Cw20HookMsg,
 };
 use cosmwasm_std::{
     to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo,
-    QuerierWrapper, Response, StdError, StdResult, Uint128, WasmMsg,
+    Response, StdError, StdResult, Uint128, WasmMsg,
 };
 
 #[cfg(not(feature = "library"))]
@@ -14,7 +14,7 @@ use cosmwasm_std::entry_point;
 
 use covenant_utils::{query_astro_pool_token, SplitConfig, SplitType};
 use cw2::set_contract_version;
-use cw20::{BalanceResponse, Cw20ExecuteMsg};
+use cw20::Cw20ExecuteMsg;
 
 use crate::msg::CovenantType;
 use crate::{

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -1,7 +1,10 @@
-use astroport::{asset::{Asset, PairInfo}, pair::Cw20HookMsg};
+use astroport::{
+    asset::{Asset, PairInfo},
+    pair::Cw20HookMsg,
+};
 use cosmwasm_std::{
-    to_binary, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo,
-    Response, StdResult, WasmMsg, Uint128, QuerierWrapper, StdError, Order,
+    to_binary, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, Order,
+    QuerierWrapper, Response, StdError, StdResult, Uint128, WasmMsg,
 };
 
 #[cfg(not(feature = "library"))]
@@ -12,10 +15,13 @@ use cw20::{BalanceResponse, Cw20ExecuteMsg};
 
 use crate::{
     error::ContractError,
-    msg::{ContractState, ExecuteMsg, InstantiateMsg, QueryMsg, RagequitConfig, RagequitState, MigrateMsg},
+    msg::{
+        ContractState, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, RagequitConfig,
+        RagequitState,
+    },
     state::{
-        CLOCK_ADDRESS, CONTRACT_STATE, COVENANT_CONFIG, DEPOSIT_DEADLINE, LOCKUP_CONFIG,
-        NEXT_CONTRACT, POOL_ADDRESS, RAGEQUIT_CONFIG, SPLIT_CONFIG_MAP, FALLBACK_SPLIT,
+        CLOCK_ADDRESS, CONTRACT_STATE, COVENANT_CONFIG, DEPOSIT_DEADLINE, FALLBACK_SPLIT,
+        LOCKUP_CONFIG, NEXT_CONTRACT, POOL_ADDRESS, RAGEQUIT_CONFIG, SPLIT_CONFIG_MAP,
     },
 };
 
@@ -36,10 +42,10 @@ pub fn instantiate(
     let clock_addr = deps.api.addr_validate(&msg.clock_address)?;
 
     if msg.deposit_deadline.is_expired(&env.block) {
-        return Err(ContractError::DepositDeadlineValidationError {})
+        return Err(ContractError::DepositDeadlineValidationError {});
     }
     if msg.lockup_config.is_expired(&env.block) {
-        return Err(ContractError::LockupValidationError {})
+        return Err(ContractError::LockupValidationError {});
     }
 
     msg.covenant_config.validate(deps.api)?;
@@ -87,7 +93,11 @@ pub fn execute(
 }
 
 /// queries the liquidity token balance of given address
-fn query_liquidity_token_balance(querier: QuerierWrapper, liquidity_token: &str, contract_addr: String) -> Result<Uint128, ContractError> {
+fn query_liquidity_token_balance(
+    querier: QuerierWrapper,
+    liquidity_token: &str,
+    contract_addr: String,
+) -> Result<Uint128, ContractError> {
     let liquidity_token_balance: BalanceResponse = querier.query_wasm_smart(
         liquidity_token,
         &cw20::Cw20QueryMsg::Balance {
@@ -98,11 +108,12 @@ fn query_liquidity_token_balance(querier: QuerierWrapper, liquidity_token: &str,
 }
 
 /// queries the cw20 liquidity token address corresponding to a given pool
-fn query_liquidity_token_address(querier: QuerierWrapper, pool: String) -> Result<String, ContractError> {
-    let pair_info: PairInfo = querier.query_wasm_smart(
-        pool,
-        &astroport::pair::QueryMsg::Pair {}
-    )?;
+fn query_liquidity_token_address(
+    querier: QuerierWrapper,
+    pool: String,
+) -> Result<String, ContractError> {
+    let pair_info: PairInfo =
+        querier.query_wasm_smart(pool, &astroport::pair::QueryMsg::Pair {})?;
     Ok(pair_info.liquidity_token.to_string())
 }
 
@@ -118,7 +129,9 @@ fn try_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Con
     // we exit early if contract is not in ragequit or expired state
     // otherwise claim process is the same
     let response: Response = match contract_state {
-        ContractState::Ragequit => Response::default().add_attribute("method", "try_claim_ragequit"),
+        ContractState::Ragequit => {
+            Response::default().add_attribute("method", "try_claim_ragequit")
+        }
         ContractState::Expired => Response::default().add_attribute("method", "try_claim_expired"),
         _ => return Err(ContractError::ClaimError {}),
     };
@@ -132,7 +145,8 @@ fn try_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Con
     }
 
     let lp_token = query_liquidity_token_address(deps.querier, pool.to_string())?;
-    let liquidity_token_balance = query_liquidity_token_balance(deps.querier, &lp_token, env.contract.address.to_string())?;
+    let liquidity_token_balance =
+        query_liquidity_token_balance(deps.querier, &lp_token, env.contract.address.to_string())?;
 
     // if no lp tokens are available, no point to ragequit
     if liquidity_token_balance.is_zero() {
@@ -201,12 +215,13 @@ fn try_tick(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Cont
         ContractState::Active => check_expiration(deps, env),
         ContractState::Expired => {
             let config = COVENANT_CONFIG.load(deps.storage)?;
-            let state = if config.party_a.allocation.is_zero() && config.party_b.allocation.is_zero() {
-                CONTRACT_STATE.save(deps.storage, &ContractState::Complete)?;
-                ContractState::Complete
-            } else {
-                state
-            };
+            let state =
+                if config.party_a.allocation.is_zero() && config.party_b.allocation.is_zero() {
+                    CONTRACT_STATE.save(deps.storage, &ContractState::Complete)?;
+                    ContractState::Complete
+                } else {
+                    state
+                };
             Ok(Response::default()
                 .add_attribute("method", "tick")
                 .add_attribute("contract_state", state.to_string()))
@@ -239,36 +254,37 @@ fn try_deposit(deps: DepsMut, env: Env, _info: MessageInfo) -> Result<Response, 
     // it is important to trigger this method before the expiry block
     // if deposit deadline is due we complete and refund
     if deposit_deadline.is_expired(&env.block) {
-        let refund_messages: Vec<CosmosMsg> = match (party_a_bal.amount.is_zero(), party_b_bal.amount.is_zero()) {
-            // both balances empty, we complete
-            (true, true) => {
-                CONTRACT_STATE.save(deps.storage, &ContractState::Complete)?;
-                return Ok(Response::default()
-                    .add_attribute("method", "try_deposit")
-                    .add_attribute("state", "complete"));
-            }
-            // refund party B
-            (true, false) => vec![CosmosMsg::Bank(BankMsg::Send {
-                to_address: config.party_b.router,
-                amount: vec![party_b_bal],
-            })],
-            // refund party A
-            (false, true) => vec![CosmosMsg::Bank(BankMsg::Send {
-                to_address: config.party_a.router,
-                amount: vec![party_a_bal],
-            })],
-            // refund both
-            (false, false) => vec![
-                CosmosMsg::Bank(BankMsg::Send {
-                    to_address: config.party_a.router.to_string(),
-                    amount: vec![party_a_bal],
-                }),
-                CosmosMsg::Bank(BankMsg::Send {
+        let refund_messages: Vec<CosmosMsg> =
+            match (party_a_bal.amount.is_zero(), party_b_bal.amount.is_zero()) {
+                // both balances empty, we complete
+                (true, true) => {
+                    CONTRACT_STATE.save(deps.storage, &ContractState::Complete)?;
+                    return Ok(Response::default()
+                        .add_attribute("method", "try_deposit")
+                        .add_attribute("state", "complete"));
+                }
+                // refund party B
+                (true, false) => vec![CosmosMsg::Bank(BankMsg::Send {
                     to_address: config.party_b.router,
                     amount: vec![party_b_bal],
-                }),
-            ],
-        };
+                })],
+                // refund party A
+                (false, true) => vec![CosmosMsg::Bank(BankMsg::Send {
+                    to_address: config.party_a.router,
+                    amount: vec![party_a_bal],
+                })],
+                // refund both
+                (false, false) => vec![
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: config.party_a.router.to_string(),
+                        amount: vec![party_a_bal],
+                    }),
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: config.party_b.router,
+                        amount: vec![party_b_bal],
+                    }),
+                ],
+            };
         return Ok(Response::default()
             .add_attribute("method", "try_deposit")
             .add_attribute("action", "refund")
@@ -334,10 +350,8 @@ fn try_ragequit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
     }
 
     // authorize the message sender
-    let (
-        mut rq_party,
-        mut counterparty
-    ) = covenant_config.authorize_sender(info.sender.to_string())?;
+    let (mut rq_party, mut counterparty) =
+        covenant_config.authorize_sender(info.sender.to_string())?;
 
     // after all validations we are ready to perform the ragequit.
     // first we apply the ragequit penalty
@@ -346,7 +360,8 @@ fn try_ragequit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
     let lp_token = query_liquidity_token_address(deps.querier, pool.to_string())?;
 
     // We query our own liquidity token balance
-    let liquidity_token_balance = query_liquidity_token_balance(deps.querier, &lp_token, env.contract.address.to_string())?;
+    let liquidity_token_balance =
+        query_liquidity_token_balance(deps.querier, &lp_token, env.contract.address.to_string())?;
 
     // if no lp tokens are available, no point to ragequit
     if liquidity_token_balance.is_zero() {
@@ -402,14 +417,11 @@ fn try_ragequit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
 
     // we submit the withdraw liquidity message followed by transfer of
     // underlying assets to the corresponding router
-    let mut withdraw_and_forward_msgs = vec![
-        CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: lp_token,
-            msg: to_binary(withdraw_msg)?,
-            funds: vec![],
-        }),
-    ];
-
+    let mut withdraw_and_forward_msgs = vec![CosmosMsg::Wasm(WasmMsg::Execute {
+        contract_addr: lp_token.to_string(),
+        msg: to_binary(withdraw_msg)?,
+        funds: vec![],
+    })];
     withdraw_and_forward_msgs.append(&mut distribution_messages);
 
     // after building the messages we can finalize the config updates.
@@ -476,7 +488,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
 
             if let Some(expiry_config) = lockup_config {
                 if expiry_config.is_expired(&env.block) {
-                    return Err(StdError::generic_err("lockup config is already past"))
+                    return Err(StdError::generic_err("lockup config is already past"));
                 }
                 LOCKUP_CONFIG.save(deps.storage, &expiry_config)?;
                 resp = resp.add_attribute("lockup_config", expiry_config.to_string());
@@ -484,7 +496,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
 
             if let Some(expiry_config) = deposit_deadline {
                 if expiry_config.is_expired(&env.block) {
-                    return Err(StdError::generic_err("deposit deadline is already past"))
+                    return Err(StdError::generic_err("deposit deadline is already past"));
                 }
                 DEPOSIT_DEADLINE.save(deps.storage, &expiry_config)?;
                 resp = resp.add_attribute("deposit_deadline", expiry_config.to_string());
@@ -507,7 +519,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
             }
 
             Ok(resp)
-        },
+        }
         MigrateMsg::UpdateCodeId { data: _ } => todo!(),
     }
 }

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -115,19 +115,27 @@ pub fn execute(
         ExecuteMsg::Ragequit {} => try_ragequit(deps, env, info),
         ExecuteMsg::Claim {} => try_claim(deps, env, info),
         ExecuteMsg::Tick {} => try_tick(deps, env, info),
-        ExecuteMsg::DistributeFallbackSplit { denoms } => try_distribute_fallback_split(deps, env, denoms),
+        ExecuteMsg::DistributeFallbackSplit { denoms } => {
+            try_distribute_fallback_split(deps, env, denoms)
+        }
     }
 }
 
-fn try_distribute_fallback_split(deps: DepsMut, env: Env, denoms: Vec<String>) -> Result<Response, ContractError> {
+fn try_distribute_fallback_split(
+    deps: DepsMut,
+    env: Env,
+    denoms: Vec<String>,
+) -> Result<Response, ContractError> {
     let mut available_balances = Vec::new();
     let denom_splits = DENOM_SPLITS.load(deps.storage)?;
 
     for denom in denoms {
         if denom_splits.explicit_splits.contains_key(&denom) {
-            return Err(ContractError::UnauthorizedDenomDistribution {})
+            return Err(ContractError::UnauthorizedDenomDistribution {});
         }
-        let queried_coin = deps.querier.query_balance(env.contract.address.to_string(), denom)?;
+        let queried_coin = deps
+            .querier
+            .query_balance(env.contract.address.to_string(), denom)?;
         available_balances.push(queried_coin);
     }
 

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -16,11 +16,12 @@ use covenant_utils::SplitConfig;
 use cw2::set_contract_version;
 use cw20::{BalanceResponse, Cw20ExecuteMsg};
 
+use crate::msg::CovenantType;
 use crate::{
     error::ContractError,
     msg::{
         ContractState, DenomSplits, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-        RagequitConfig, RagequitState, RagequitTerms, RagequitType, TwoPartyPolCovenantConfig,
+        RagequitConfig, RagequitState, RagequitTerms, TwoPartyPolCovenantConfig,
         TwoPartyPolCovenantParty,
     },
     state::{
@@ -377,8 +378,8 @@ fn try_ragequit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
 
     // depending on the type of ragequit configuration,
     // different logic we execute
-    match rq_config.ty {
-        RagequitType::Share => try_handle_share_based_ragequit(
+    match covenant_config.covenant_type {
+        CovenantType::Share => try_handle_share_based_ragequit(
             deps,
             rq_party,
             counterparty,
@@ -388,7 +389,7 @@ fn try_ragequit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
             rq_config,
             covenant_config,
         ),
-        RagequitType::Side => try_handle_side_based_ragequit(
+        CovenantType::Side => try_handle_side_based_ragequit(
             deps,
             rq_party,
             counterparty,

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, borrow::BorrowMut};
+use std::{collections::BTreeMap};
 
 use astroport::{
     asset::{Asset, PairInfo},

--- a/contracts/two-party-pol-holder/src/error.rs
+++ b/contracts/two-party-pol-holder/src/error.rs
@@ -62,4 +62,7 @@ pub enum ContractError {
 
     #[error("no lp tokens available")]
     NoLpTokensAvailable {},
+
+    #[error("unauthorized to distribute explicitly defined denom")]
+    UnauthorizedDenomDistribution {},
 }

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -172,7 +172,7 @@ impl DenomSplits {
                 .receivers
                 // get current party shares or error out if not found
                 .get(&party.router)
-                .ok_or_else(|| ContractError::PartyNotFound {})?;
+                .ok_or(ContractError::PartyNotFound {})?;
 
             // we do not penalize already null allocations of
             // the ragequitting party
@@ -180,14 +180,14 @@ impl DenomSplits {
                 let new_party_share = party_share
                     // add the penalty or return overflow
                     .checked_sub(penalty)
-                    .map_err(|e| StdError::overflow(e))?;
+                    .map_err(StdError::overflow)?;
 
                 let new_counterparty_share = config
                     .receivers
                     .get(&counterparty.router)
-                    .ok_or_else(|| ContractError::PartyNotFound {})?
+                    .ok_or(ContractError::PartyNotFound {})?
                     .checked_add(penalty)
-                    .map_err(|e| StdError::overflow(e))?;
+                    .map_err(StdError::overflow)?;
 
                 // override existing entries with the updated values
                 // while keeping the keys
@@ -209,17 +209,17 @@ impl DenomSplits {
                 .receivers
                 // get current party shares or error out if not found
                 .get(party.router.as_str())
-                .ok_or_else(|| ContractError::PartyNotFound {})?
+                .ok_or(ContractError::PartyNotFound {})?
                 // add the penalty or return overflow
                 .checked_sub(penalty)
-                .map_err(|e| StdError::overflow(e))?;
+                .map_err(StdError::overflow)?;
 
             let new_counterparty_share = split_config
                 .receivers
                 .get(counterparty.router.as_str())
-                .ok_or_else(|| ContractError::PartyNotFound {})?
+                .ok_or(ContractError::PartyNotFound {})?
                 .checked_add(penalty)
-                .map_err(|e| StdError::overflow(e))?;
+                .map_err(StdError::overflow)?;
 
             // override existing entries with the updated values
             // while keeping the keys
@@ -462,7 +462,7 @@ impl ContractState {
         match self {
             ContractState::Ragequit => Ok(()),
             ContractState::Expired => Ok(()),
-            _ => return Err(ContractError::ClaimError {}),
+            _ => Err(ContractError::ClaimError {}),
         }
     }
 }

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -42,6 +42,12 @@ impl InstantiateMsg {
 }
 
 #[cw_serde]
+pub enum CovenantType {
+    Share,
+    Side,
+}
+
+#[cw_serde]
 pub struct DenomSplits {
     pub explicit_splits: BTreeMap<String, SplitConfig>,
     pub fallback_split: Option<SplitConfig>,
@@ -49,6 +55,8 @@ pub struct DenomSplits {
 
 impl DenomSplits {
     pub fn get_distribution_messages(self, available_coins: Vec<Coin>) -> Vec<CosmosMsg> {
+        // TODO: reverse this to loop over explicit splits instead of available coins
+        // TODO: move fallback split distribution into a separate method
         available_coins
             .iter()
             .filter_map(|c| {
@@ -150,6 +158,7 @@ pub struct PresetTwoPartyPolHolderFields {
     pub label: String,
     pub splits: Vec<DenomSplit>,
     pub fallback_split: Option<SplitType>,
+    pub covenant_type: CovenantType,
 }
 
 #[cw_serde]
@@ -218,6 +227,7 @@ impl PresetTwoPartyPolHolderFields {
                     host_addr: self.party_b.host_addr,
                     controller_addr: self.party_b.controller_addr,
                 },
+                covenant_type: self.covenant_type,
             },
             splits: remapped_splits,
             fallback_split: remapped_fallback,
@@ -229,6 +239,7 @@ impl PresetTwoPartyPolHolderFields {
 pub struct TwoPartyPolCovenantConfig {
     pub party_a: TwoPartyPolCovenantParty,
     pub party_b: TwoPartyPolCovenantParty,
+    pub covenant_type: CovenantType,
 }
 
 impl TwoPartyPolCovenantConfig {
@@ -418,14 +429,6 @@ pub struct RagequitTerms {
     /// optional rq state. none indicates no ragequit.
     /// some holds the ragequit related config
     pub state: Option<RagequitState>,
-    /// describes the ragequit dynamics
-    pub ty: RagequitType,
-}
-
-#[cw_serde]
-pub enum RagequitType {
-    Share,
-    Side,
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -6,8 +6,8 @@ use cosmwasm_std::{Addr, Api, Attribute, Binary, Coin, Decimal, StdError};
 use covenant_macros::{
     clocked, covenant_clock_address, covenant_deposit_address, covenant_next_contract,
 };
-use cw_utils::Expiration;
 use covenant_utils::{DenomSplit, SplitType};
+use cw_utils::Expiration;
 
 use crate::error::ContractError;
 

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -88,6 +88,7 @@ pub struct DenomSplits {
     pub fallback_split: Option<SplitConfig>,
 }
 
+// TODO: try to generalize these implementations
 impl DenomSplits {
     pub fn get_fallback_distribution_messages(self, available_coins: Vec<Coin>) -> Vec<CosmosMsg> {
         available_coins
@@ -420,7 +421,7 @@ pub enum ExecuteMsg {
     /// withdraw the liquidity party is entitled to
     Claim {},
     /// distribute any unspecified denoms
-    DistributeFallbackSplit {},
+    DistributeFallbackSplit { denoms: Vec<String> },
 }
 
 #[cw_serde]

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -31,10 +31,11 @@ pub struct InstantiateMsg {
     pub splits: BTreeMap<String, SplitType>,
     /// a split for all denoms that are not covered in the
     /// regular `splits` list
-    pub fallback_split: Option<SplitType>,
+    pub fallback_split: Option<SplitConfig>,
 }
 
 impl InstantiateMsg {
+    // TODO: extend with all props
     pub fn get_response_attributes(&self) -> Vec<Attribute> {
         let mut attrs = vec![
             Attribute::new("clock_addr", self.clock_address.to_string()),
@@ -203,7 +204,7 @@ pub struct PresetTwoPartyPolHolderFields {
     pub code_id: u64,
     pub label: String,
     pub splits: Vec<DenomSplit>,
-    pub fallback_split: Option<SplitType>,
+    pub fallback_split: Option<SplitConfig>,
     pub covenant_type: CovenantType,
 }
 
@@ -233,20 +234,21 @@ impl PresetTwoPartyPolHolderFields {
                         self.party_b.controller_addr.to_string(),
                         party_b_router.to_string(),
                     )?;
-                    remapped_splits.insert(denom_split.denom.to_string(), remapped_split);
+                    remapped_splits.insert(
+                        denom_split.denom.to_string(),
+                        SplitType::Custom(remapped_split),
+                    );
                 }
             }
         }
 
         let remapped_fallback = match &self.fallback_split {
-            Some(split_type) => match split_type {
-                SplitType::Custom(config) => Some(config.remap_receivers_to_routers(
-                    self.party_a.controller_addr.to_string(),
-                    party_a_router.to_string(),
-                    self.party_b.controller_addr.to_string(),
-                    party_b_router.to_string(),
-                )?),
-            },
+            Some(split_config) => Some(split_config.remap_receivers_to_routers(
+                self.party_a.controller_addr.to_string(),
+                party_a_router.to_string(),
+                self.party_b.controller_addr.to_string(),
+                party_b_router.to_string(),
+            )?),
             None => None,
         };
 

--- a/contracts/two-party-pol-holder/src/state.rs
+++ b/contracts/two-party-pol-holder/src/state.rs
@@ -3,7 +3,7 @@ use covenant_utils::SplitConfig;
 use cw_storage_plus::Item;
 use cw_utils::Expiration;
 
-use crate::msg::{ContractState, RagequitConfig, TwoPartyPolCovenantConfig, DenomSplits};
+use crate::msg::{ContractState, DenomSplits, RagequitConfig, TwoPartyPolCovenantConfig};
 
 pub const CONTRACT_STATE: Item<ContractState> = Item::new("contract_state");
 

--- a/contracts/two-party-pol-holder/src/state.rs
+++ b/contracts/two-party-pol-holder/src/state.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::Addr;
-use cw_storage_plus::Item;
+use covenant_utils::SplitConfig;
+use cw_storage_plus::{Item, Map};
 use cw_utils::Expiration;
 
 use crate::msg::{ContractState, RagequitConfig, TwoPartyPolCovenantConfig};
@@ -29,3 +30,9 @@ pub const RAGEQUIT_CONFIG: Item<RagequitConfig> = Item::new("ragequit_config");
 
 /// configuration storing both parties information
 pub const COVENANT_CONFIG: Item<TwoPartyPolCovenantConfig> = Item::new("covenant_config");
+
+/// maps a denom string to a vec of SplitReceivers
+pub const SPLIT_CONFIG_MAP: Map<String, SplitConfig> = Map::new("split_config");
+
+/// split for all denoms that are not explicitly defined in SPLIT_CONFIG_MAP
+pub const FALLBACK_SPLIT: Item<SplitConfig> = Item::new("fallback_split");

--- a/contracts/two-party-pol-holder/src/state.rs
+++ b/contracts/two-party-pol-holder/src/state.rs
@@ -1,5 +1,4 @@
 use cosmwasm_std::Addr;
-use covenant_utils::SplitConfig;
 use cw_storage_plus::Item;
 use cw_utils::Expiration;
 

--- a/contracts/two-party-pol-holder/src/state.rs
+++ b/contracts/two-party-pol-holder/src/state.rs
@@ -1,9 +1,9 @@
 use cosmwasm_std::Addr;
 use covenant_utils::SplitConfig;
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::Item;
 use cw_utils::Expiration;
 
-use crate::msg::{ContractState, RagequitConfig, TwoPartyPolCovenantConfig};
+use crate::msg::{ContractState, RagequitConfig, TwoPartyPolCovenantConfig, DenomSplits};
 
 pub const CONTRACT_STATE: Item<ContractState> = Item::new("contract_state");
 
@@ -31,8 +31,5 @@ pub const RAGEQUIT_CONFIG: Item<RagequitConfig> = Item::new("ragequit_config");
 /// configuration storing both parties information
 pub const COVENANT_CONFIG: Item<TwoPartyPolCovenantConfig> = Item::new("covenant_config");
 
-/// maps a denom string to a vec of SplitReceivers
-pub const SPLIT_CONFIG_MAP: Map<String, SplitConfig> = Map::new("split_config");
-
-/// split for all denoms that are not explicitly defined in SPLIT_CONFIG_MAP
-pub const FALLBACK_SPLIT: Item<SplitConfig> = Item::new("fallback_split");
+/// stores the configuration describing how to distribute every denom
+pub const DENOM_SPLITS: Item<DenomSplits> = Item::new("denom_splits");

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -3,6 +3,7 @@ use crate::msg::{
     TwoPartyPolCovenantParty,
 };
 use cosmwasm_std::{Addr, BlockInfo, Coin, Decimal, Timestamp, Uint128};
+use covenant_utils::{DenomSplit, SplitConfig, SplitType, Receiver};
 use cw_multi_test::{App, AppResponse, Executor, SudoMsg};
 use cw_utils::Expiration;
 
@@ -73,6 +74,15 @@ impl Default for SuiteBuilder {
                         allocation: Decimal::from_ratio(Uint128::one(), Uint128::new(2)),
                     },
                 },
+                splits: vec![
+                    (DENOM_A.to_string(), SplitType::Custom(SplitConfig { receivers: vec![
+                            Receiver { addr: PARTY_A_ROUTER.to_string(), share: Uint128::new(100) }
+                    ]})),
+                    (DENOM_B.to_string(), SplitType::Custom(SplitConfig { receivers: vec![
+                            Receiver { addr: PARTY_B_ROUTER.to_string(), share: Uint128::new(100) }
+                    ]})),
+                ],
+                fallback_split: None,
             },
             app: App::default(),
         }

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -117,7 +117,7 @@ impl SuiteBuilder {
         self
     }
 
-    pub fn with_fallback_split(mut self, split: SplitType) -> Self {
+    pub fn with_fallback_split(mut self, split: SplitConfig) -> Self {
         self.instantiate.fallback_split = Some(split);
         self
     }

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -80,7 +80,7 @@ impl Default for SuiteBuilder {
                         SplitType::Custom(SplitConfig {
                             receivers: vec![Receiver {
                                 addr: PARTY_A_ROUTER.to_string(),
-                                share: Uint128::new(100),
+                                share: Decimal::one(),
                             }],
                         }),
                     ),
@@ -89,7 +89,7 @@ impl Default for SuiteBuilder {
                         SplitType::Custom(SplitConfig {
                             receivers: vec![Receiver {
                                 addr: PARTY_B_ROUTER.to_string(),
-                                share: Uint128::new(100),
+                                share: Decimal::one(),
                             }],
                         }),
                     ),

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -3,7 +3,7 @@ use crate::msg::{
     TwoPartyPolCovenantParty,
 };
 use cosmwasm_std::{Addr, BlockInfo, Coin, Decimal, Timestamp, Uint128};
-use covenant_utils::{DenomSplit, SplitConfig, SplitType, Receiver};
+use covenant_utils::{DenomSplit, Receiver, SplitConfig, SplitType};
 use cw_multi_test::{App, AppResponse, Executor, SudoMsg};
 use cw_utils::Expiration;
 
@@ -75,12 +75,24 @@ impl Default for SuiteBuilder {
                     },
                 },
                 splits: vec![
-                    (DENOM_A.to_string(), SplitType::Custom(SplitConfig { receivers: vec![
-                            Receiver { addr: PARTY_A_ROUTER.to_string(), share: Uint128::new(100) }
-                    ]})),
-                    (DENOM_B.to_string(), SplitType::Custom(SplitConfig { receivers: vec![
-                            Receiver { addr: PARTY_B_ROUTER.to_string(), share: Uint128::new(100) }
-                    ]})),
+                    (
+                        DENOM_A.to_string(),
+                        SplitType::Custom(SplitConfig {
+                            receivers: vec![Receiver {
+                                addr: PARTY_A_ROUTER.to_string(),
+                                share: Uint128::new(100),
+                            }],
+                        }),
+                    ),
+                    (
+                        DENOM_B.to_string(),
+                        SplitType::Custom(SplitConfig {
+                            receivers: vec![Receiver {
+                                addr: PARTY_B_ROUTER.to_string(),
+                                share: Uint128::new(100),
+                            }],
+                        }),
+                    ),
                 ],
                 fallback_split: None,
             },

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -244,7 +244,11 @@ impl Suite {
         )
     }
 
-    pub fn distribute_fallback(&mut self, caller: &str, denoms: Vec<String>) -> Result<AppResponse, anyhow::Error> {
+    pub fn distribute_fallback(
+        &mut self,
+        caller: &str,
+        denoms: Vec<String>,
+    ) -> Result<AppResponse, anyhow::Error> {
         self.app.execute_contract(
             Addr::unchecked(caller),
             self.holder.clone(),

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -73,6 +73,7 @@ impl Default for SuiteBuilder {
                         controller_addr: PARTY_B_ADDR.to_string(),
                         allocation: Decimal::from_ratio(Uint128::one(), Uint128::new(2)),
                     },
+                    covenant_type: crate::msg::CovenantType::Share{},
                 },
                 splits: vec![
                     (

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -244,11 +244,11 @@ impl Suite {
         )
     }
 
-    pub fn distribute_fallback(&mut self, caller: &str) -> Result<AppResponse, anyhow::Error> {
+    pub fn distribute_fallback(&mut self, caller: &str, denoms: Vec<String>) -> Result<AppResponse, anyhow::Error> {
         self.app.execute_contract(
             Addr::unchecked(caller),
             self.holder.clone(),
-            &ExecuteMsg::DistributeFallbackSplit {},
+            &ExecuteMsg::DistributeFallbackSplit { denoms },
             &[],
         )
     }

--- a/contracts/two-party-pol-holder/src/suite_tests/suite.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/suite.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, str::FromStr};
 
 use crate::msg::{
-    ContractState, ExecuteMsg, InstantiateMsg, QueryMsg, RagequitConfig, TwoPartyPolCovenantConfig,
-    TwoPartyPolCovenantParty, CovenantType,
+    ContractState, CovenantType, ExecuteMsg, InstantiateMsg, QueryMsg, RagequitConfig,
+    TwoPartyPolCovenantConfig, TwoPartyPolCovenantParty,
 };
 use cosmwasm_std::{Addr, BlockInfo, Coin, Decimal, Timestamp, Uint128};
 use covenant_utils::{SplitConfig, SplitType};
@@ -45,22 +45,39 @@ pub struct SuiteBuilder {
 }
 
 impl Default for SuiteBuilder {
-
     fn default() -> Self {
         let mut denom_a_split = BTreeMap::new();
-        denom_a_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("0.5").unwrap());
-        denom_a_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("0.5").unwrap());
+        denom_a_split.insert(
+            PARTY_A_ROUTER.to_string(),
+            Decimal::from_str("0.5").unwrap(),
+        );
+        denom_a_split.insert(
+            PARTY_B_ROUTER.to_string(),
+            Decimal::from_str("0.5").unwrap(),
+        );
         let mut denom_b_split = BTreeMap::new();
-        denom_b_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("0.5").unwrap());
-        denom_b_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("0.5").unwrap());
+        denom_b_split.insert(
+            PARTY_A_ROUTER.to_string(),
+            Decimal::from_str("0.5").unwrap(),
+        );
+        denom_b_split.insert(
+            PARTY_B_ROUTER.to_string(),
+            Decimal::from_str("0.5").unwrap(),
+        );
 
         let mut splits = BTreeMap::new();
-        splits.insert(DENOM_A.to_string(), SplitType::Custom(SplitConfig {
-            receivers: denom_a_split,
-        }));
-        splits.insert(DENOM_B.to_string(), SplitType::Custom(SplitConfig {
-            receivers: denom_b_split,
-        }));
+        splits.insert(
+            DENOM_A.to_string(),
+            SplitType::Custom(SplitConfig {
+                receivers: denom_a_split,
+            }),
+        );
+        splits.insert(
+            DENOM_B.to_string(),
+            SplitType::Custom(SplitConfig {
+                receivers: denom_b_split,
+            }),
+        );
 
         Self {
             instantiate: InstantiateMsg {
@@ -91,7 +108,7 @@ impl Default for SuiteBuilder {
                         controller_addr: PARTY_B_ADDR.to_string(),
                         allocation: Decimal::from_ratio(Uint128::one(), Uint128::new(2)),
                     },
-                    covenant_type: crate::msg::CovenantType::Share{},
+                    covenant_type: crate::msg::CovenantType::Share {},
                 },
                 splits,
                 fallback_split: None,
@@ -372,10 +389,7 @@ impl Suite {
     }
 
     pub fn get_coin(&mut self, denom: String, amount: Uint128) -> Coin {
-        Coin {
-            denom,
-            amount
-        }
+        Coin { denom, amount }
     }
 }
 

--- a/contracts/two-party-pol-holder/src/suite_tests/tests.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/tests.rs
@@ -41,6 +41,7 @@ fn test_invalid_ragequit_penalty() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::one(),
             state: None,
+            ty: crate::msg::RagequitType::Side,
         }))
         .build();
 }
@@ -52,6 +53,7 @@ fn test_ragequit_penalty_exceeds_either_party_allocation() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::percent(51),
             state: None,
+            ty: crate::msg::RagequitType::Side,
         }))
         .build();
 }
@@ -280,6 +282,7 @@ fn test_holder_ragequit_unauthorized() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::from_ratio(Uint128::one(), Uint128::new(10)),
             state: None,
+            ty: crate::msg::RagequitType::Side,
         }))
         .build();
 
@@ -339,6 +342,7 @@ fn test_holder_ragequit_active_but_expired() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::bps(10),
             state: None,
+            ty: crate::msg::RagequitType::Side,
         }))
         .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();
@@ -367,6 +371,7 @@ fn test_ragequit_double_claim_fails() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::from_ratio(Uint128::one(), Uint128::new(10)),
             state: None,
+            ty: crate::msg::RagequitType::Side,
         }))
         .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();
@@ -405,6 +410,7 @@ fn test_ragequit_happy_flow_to_completion() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::from_ratio(Uint128::one(), Uint128::new(10)),
             state: None,
+            ty: crate::msg::RagequitType::Side,
         }))
         .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();

--- a/contracts/two-party-pol-holder/src/suite_tests/tests.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/tests.rs
@@ -792,24 +792,25 @@ fn test_distribute_fallback_split() {
     assert_eq!(1, suite.get_all_balances(PARTY_A_ROUTER.to_string()).len());
     assert_eq!(2, suite.get_all_balances(PARTY_B_ROUTER.to_string()).len());
 
-
     // first try to distribute the explicit denom which should fail
     suite.fund_coin(coin_a);
-    let err: ContractError = suite.distribute_fallback("random", vec![DENOM_A.to_string()])
+    let err: ContractError = suite
+        .distribute_fallback("random", vec![DENOM_A.to_string()])
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, ContractError::UnauthorizedDenomDistribution {  });
+    assert_eq!(err, ContractError::UnauthorizedDenomDistribution {});
 
     // try to distribute mix of explicitly defined denoms and fallback
     let mut random_denoms = Vec::new();
     random_denoms.extend(denoms.clone());
     random_denoms.push(DENOM_A.to_string());
-    let err: ContractError = suite.distribute_fallback("random", vec![DENOM_A.to_string()])
+    let err: ContractError = suite
+        .distribute_fallback("random", vec![DENOM_A.to_string()])
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, ContractError::UnauthorizedDenomDistribution {  });
+    assert_eq!(err, ContractError::UnauthorizedDenomDistribution {});
 
     // distribute the fallback and assert it arrives
     suite.distribute_fallback("random", denoms).unwrap();

--- a/contracts/two-party-pol-holder/src/suite_tests/tests.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/tests.rs
@@ -696,7 +696,7 @@ fn test_distribute_fallback_split() {
                 state: None,
             })
         )
-        .with_fallback_split(SplitType::Custom(SplitConfig { receivers: fallback_split }))
+        .with_fallback_split(SplitConfig { receivers: fallback_split })
         .with_lockup_config(Expiration::AtTime(
             current_timestamp.time.plus_minutes(200))
         )

--- a/contracts/two-party-pol-holder/src/suite_tests/tests.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/tests.rs
@@ -41,7 +41,6 @@ fn test_invalid_ragequit_penalty() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::one(),
             state: None,
-            ty: crate::msg::RagequitType::Side,
         }))
         .build();
 }
@@ -53,7 +52,6 @@ fn test_ragequit_penalty_exceeds_either_party_allocation() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::percent(51),
             state: None,
-            ty: crate::msg::RagequitType::Side,
         }))
         .build();
 }
@@ -282,7 +280,6 @@ fn test_holder_ragequit_unauthorized() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::from_ratio(Uint128::one(), Uint128::new(10)),
             state: None,
-            ty: crate::msg::RagequitType::Side,
         }))
         .build();
 
@@ -342,7 +339,6 @@ fn test_holder_ragequit_active_but_expired() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::bps(10),
             state: None,
-            ty: crate::msg::RagequitType::Side,
         }))
         .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();
@@ -371,7 +367,6 @@ fn test_ragequit_double_claim_fails() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::from_ratio(Uint128::one(), Uint128::new(10)),
             state: None,
-            ty: crate::msg::RagequitType::Side,
         }))
         .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();
@@ -410,7 +405,6 @@ fn test_ragequit_happy_flow_to_completion() {
         .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
             penalty: Decimal::from_ratio(Uint128::one(), Uint128::new(10)),
             state: None,
-            ty: crate::msg::RagequitType::Side,
         }))
         .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();

--- a/contracts/two-party-pol-holder/src/suite_tests/tests.rs
+++ b/contracts/two-party-pol-holder/src/suite_tests/tests.rs
@@ -1,15 +1,15 @@
-use std::{str::FromStr, collections::BTreeMap};
+use std::{collections::BTreeMap, str::FromStr};
 
-use cosmwasm_std::{Decimal, Timestamp, Uint128, Addr};
-use covenant_utils::{SplitType, SplitConfig};
+use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
+use covenant_utils::{SplitConfig, SplitType};
 use cw_utils::Expiration;
 
 use crate::{
     error::ContractError,
     msg::{ContractState, RagequitConfig, RagequitTerms},
     suite_tests::suite::{
-        get_default_block_info, CLOCK_ADDR, NEXT_CONTRACT, PARTY_A_ROUTER, PARTY_B_ADDR,
-        PARTY_B_ROUTER, POOL, DENOM_A, DENOM_B,
+        get_default_block_info, CLOCK_ADDR, DENOM_A, DENOM_B, NEXT_CONTRACT, PARTY_A_ROUTER,
+        PARTY_B_ADDR, PARTY_B_ROUTER, POOL,
     },
 };
 
@@ -536,23 +536,40 @@ fn test_share_based_expiry_happy_flow_to_completion() {
     assert_eq!(ContractState::Complete {}, suite.query_contract_state());
 }
 
-
 #[test]
 fn test_side_based_expiry_happy_flow_to_completion() {
     let current_timestamp = get_default_block_info();
     let mut denom_a_split = BTreeMap::new();
-    denom_a_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("1.0").unwrap());
-    denom_a_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("0.0").unwrap());
+    denom_a_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("1.0").unwrap(),
+    );
+    denom_a_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("0.0").unwrap(),
+    );
     let mut denom_b_split = BTreeMap::new();
-    denom_b_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("0.0").unwrap());
-    denom_b_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("1.0").unwrap());
+    denom_b_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("0.0").unwrap(),
+    );
+    denom_b_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("1.0").unwrap(),
+    );
     let mut splits = BTreeMap::new();
-    splits.insert(DENOM_A.to_string(), SplitType::Custom(SplitConfig {
-        receivers: denom_a_split,
-    }));
-    splits.insert(DENOM_B.to_string(), SplitType::Custom(SplitConfig {
-        receivers: denom_b_split,
-    }));
+    splits.insert(
+        DENOM_A.to_string(),
+        SplitType::Custom(SplitConfig {
+            receivers: denom_a_split,
+        }),
+    );
+    splits.insert(
+        DENOM_B.to_string(),
+        SplitType::Custom(SplitConfig {
+            receivers: denom_b_split,
+        }),
+    );
     let mut suite = SuiteBuilder::default()
         .with_splits(splits)
         .with_covenant_config_type(crate::msg::CovenantType::Side)
@@ -604,35 +621,48 @@ fn test_side_based_expiry_happy_flow_to_completion() {
     assert_eq!(ContractState::Complete {}, suite.query_contract_state());
 }
 
-
 #[test]
 fn test_side_based_ragequit_flow_to_completion() {
     let current_timestamp = get_default_block_info();
     let mut denom_a_split = BTreeMap::new();
-    denom_a_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("1.0").unwrap());
-    denom_a_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("0.0").unwrap());
+    denom_a_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("1.0").unwrap(),
+    );
+    denom_a_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("0.0").unwrap(),
+    );
     let mut denom_b_split = BTreeMap::new();
-    denom_b_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("0.0").unwrap());
-    denom_b_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("1.0").unwrap());
+    denom_b_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("0.0").unwrap(),
+    );
+    denom_b_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("1.0").unwrap(),
+    );
     let mut splits = BTreeMap::new();
-    splits.insert(DENOM_A.to_string(), SplitType::Custom(SplitConfig {
-        receivers: denom_a_split,
-    }));
-    splits.insert(DENOM_B.to_string(), SplitType::Custom(SplitConfig {
-        receivers: denom_b_split,
-    }));
+    splits.insert(
+        DENOM_A.to_string(),
+        SplitType::Custom(SplitConfig {
+            receivers: denom_a_split,
+        }),
+    );
+    splits.insert(
+        DENOM_B.to_string(),
+        SplitType::Custom(SplitConfig {
+            receivers: denom_b_split,
+        }),
+    );
     let mut suite = SuiteBuilder::default()
         .with_splits(splits)
         .with_covenant_config_type(crate::msg::CovenantType::Side)
-        .with_ragequit_config(RagequitConfig::Enabled(
-            RagequitTerms {
-                penalty: Decimal::from_str("0.1").unwrap(),
-                state: None,
-            })
-        )
-        .with_lockup_config(Expiration::AtTime(
-            current_timestamp.time.plus_minutes(200))
-        )
+        .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
+            penalty: Decimal::from_str("0.1").unwrap(),
+            state: None,
+        }))
+        .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();
 
     // both parties fulfill their parts of the covenant
@@ -664,42 +694,63 @@ fn test_side_based_ragequit_flow_to_completion() {
     );
 }
 
-
 #[test]
 fn test_distribute_fallback_split() {
     let current_timestamp = get_default_block_info();
     let mut denom_a_split = BTreeMap::new();
-    denom_a_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("1.0").unwrap());
-    denom_a_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("0.0").unwrap());
+    denom_a_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("1.0").unwrap(),
+    );
+    denom_a_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("0.0").unwrap(),
+    );
     let mut denom_b_split = BTreeMap::new();
-    denom_b_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("0.0").unwrap());
-    denom_b_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("1.0").unwrap());
+    denom_b_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("0.0").unwrap(),
+    );
+    denom_b_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("1.0").unwrap(),
+    );
 
     let mut fallback_split = BTreeMap::new();
-    fallback_split.insert(PARTY_A_ROUTER.to_string(), Decimal::from_str("0.5").unwrap());
-    fallback_split.insert(PARTY_B_ROUTER.to_string(), Decimal::from_str("0.5").unwrap());
+    fallback_split.insert(
+        PARTY_A_ROUTER.to_string(),
+        Decimal::from_str("0.5").unwrap(),
+    );
+    fallback_split.insert(
+        PARTY_B_ROUTER.to_string(),
+        Decimal::from_str("0.5").unwrap(),
+    );
 
     let mut splits = BTreeMap::new();
-    splits.insert(DENOM_A.to_string(), SplitType::Custom(SplitConfig {
-        receivers: denom_a_split,
-    }));
-    splits.insert(DENOM_B.to_string(), SplitType::Custom(SplitConfig {
-        receivers: denom_b_split,
-    }));
+    splits.insert(
+        DENOM_A.to_string(),
+        SplitType::Custom(SplitConfig {
+            receivers: denom_a_split,
+        }),
+    );
+    splits.insert(
+        DENOM_B.to_string(),
+        SplitType::Custom(SplitConfig {
+            receivers: denom_b_split,
+        }),
+    );
 
     let mut suite = SuiteBuilder::default()
         .with_splits(splits)
         .with_covenant_config_type(crate::msg::CovenantType::Side)
-        .with_ragequit_config(RagequitConfig::Enabled(
-            RagequitTerms {
-                penalty: Decimal::from_str("0.1").unwrap(),
-                state: None,
-            })
-        )
-        .with_fallback_split(SplitConfig { receivers: fallback_split })
-        .with_lockup_config(Expiration::AtTime(
-            current_timestamp.time.plus_minutes(200))
-        )
+        .with_ragequit_config(RagequitConfig::Enabled(RagequitTerms {
+            penalty: Decimal::from_str("0.1").unwrap(),
+            state: None,
+        }))
+        .with_fallback_split(SplitConfig {
+            receivers: fallback_split,
+        })
+        .with_lockup_config(Expiration::AtTime(current_timestamp.time.plus_minutes(200)))
         .build();
 
     // both parties fulfill their parts of the covenant
@@ -741,10 +792,15 @@ fn test_distribute_fallback_split() {
     // distribute the fallback and assert it arrives
     suite.fund_coin(coin_a);
     suite.distribute_fallback("random").unwrap();
-    assert_eq!(101, suite.get_all_balances(PARTY_A_ROUTER.to_string()).len());
-    assert_eq!(102, suite.get_all_balances(PARTY_B_ROUTER.to_string()).len());
+    assert_eq!(
+        101,
+        suite.get_all_balances(PARTY_A_ROUTER.to_string()).len()
+    );
+    assert_eq!(
+        102,
+        suite.get_all_balances(PARTY_B_ROUTER.to_string()).len()
+    );
 
     // relevant denoms don't get distributed with fallback
     assert_eq!(1, suite.get_all_balances(suite.holder.to_string()).len());
 }
-

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ local-e2e-rebuild TEST: optimize
     fi
     cp -R artifacts/*.wasm {{TEST}}/tests/interchaintest/wasms
     ls {{TEST}}/tests/interchaintest/wasms
-    cd {{TEST}}/tests/interchaintest/ && go test -timeout 30m -v
+    cd {{TEST}}/tests/interchaintest/ && go test -timeout 40m -v
 
 local-e2e TEST:
-    cd {{TEST}}/tests/interchaintest/ && go test -timeout 30m -v
+    cd {{TEST}}/tests/interchaintest/ && go test -timeout 40m -v

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ local-e2e-rebuild TEST: optimize
     fi
     cp -R artifacts/*.wasm {{TEST}}/tests/interchaintest/wasms
     ls {{TEST}}/tests/interchaintest/wasms
-    cd {{TEST}}/tests/interchaintest/ && go test -timeout 40m -v
+    cd {{TEST}}/tests/interchaintest/ && go test -timeout 50m -v
 
 local-e2e TEST:
     cd {{TEST}}/tests/interchaintest/ && go test -timeout 40m -v

--- a/packages/covenant-macros/src/lib.rs
+++ b/packages/covenant-macros/src/lib.rs
@@ -23,7 +23,7 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
         }),
     ) = (&mut left.data, right.data)
     {
-        variants.extend(to_add.into_iter());
+        variants.extend(to_add);
 
         quote! { #left }.into()
     } else {

--- a/packages/covenant-utils/Cargo.toml
+++ b/packages/covenant-utils/Cargo.toml
@@ -15,3 +15,5 @@ neutron-sdk      = { workspace = true }
 cosmwasm-std     = { workspace = true }
 prost            = { workspace = true }
 cosmos-sdk-proto = { workspace = true }
+cw20             = { workspace = true }
+astroport        = { workspace = true }

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -284,12 +284,12 @@ impl SplitConfig {
         Ok(msgs?)
     }
 
-    pub fn get_response_attribute(self, denom: String) -> Attribute {
+    pub fn get_response_attribute(&self, denom: String) -> Attribute {
         let mut receivers = "[".to_string();
         self.receivers.iter().for_each(|(receiver, share)| {
             receivers.push('(');
             receivers.push_str(&receiver);
-            receivers.push(',');
+            receivers.push(':');
             receivers.push_str(&share.to_string());
             receivers.push_str("),");
         });

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -201,7 +201,7 @@ impl SplitConfig {
         router_a: String,
         receiver_b: String,
         router_b: String,
-    ) -> Result<SplitType, StdError> {
+    ) -> Result<SplitConfig, StdError> {
         let mut new_receivers = BTreeMap::new();
 
         match self.receivers.get(&receiver_a) {
@@ -213,11 +213,10 @@ impl SplitConfig {
             None => return Err(StdError::NotFound { kind: format!("receiver {:?} not found", receiver_b) }),
         };
 
-        Ok(SplitType::Custom(SplitConfig { receivers: new_receivers }))
+        Ok(SplitConfig { receivers: new_receivers })
     }
 
-    pub fn validate(self, party_a: &str, party_b: &str) -> Result<SplitConfig, StdError> {
-
+    pub fn validate(&self, party_a: &str, party_b: &str) -> Result<(), StdError> {
         let share_a = match self.receivers.get(party_a) {
             Some(val) => *val,
             None => return Err(StdError::not_found(party_a)),
@@ -233,7 +232,7 @@ impl SplitConfig {
             ))
         }
 
-        Ok(self)
+        Ok(())
     }
 
     pub fn get_transfer_messages(

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -1,16 +1,15 @@
-use std::{collections::BTreeMap, io::Stderr};
+use astroport::asset::PairInfo;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     Addr, Attribute, BankMsg, BlockInfo, Coin, CosmosMsg, Decimal, Fraction, IbcMsg, IbcTimeout,
-    StdError, Timestamp, Uint128, Uint64, QuerierWrapper,
+    QuerierWrapper, StdError, Timestamp, Uint128, Uint64,
 };
 use cw20::BalanceResponse;
 use neutron_sdk::{
     bindings::msg::{IbcFee, NeutronMsg},
     sudo::msg::RequestPacketTimeoutHeight,
 };
-use astroport::asset::PairInfo;
-
+use std::{collections::BTreeMap, io::Stderr};
 
 pub mod neutron_ica {
     use cosmwasm_schema::{cw_serde, QueryResponses};
@@ -196,7 +195,6 @@ pub struct SplitConfig {
     pub receivers: BTreeMap<String, Decimal>,
 }
 
-
 impl SplitConfig {
     pub fn remap_receivers_to_routers(
         &self,
@@ -209,14 +207,24 @@ impl SplitConfig {
 
         match self.receivers.get(&receiver_a) {
             Some(val) => new_receivers.insert(router_a, *val),
-            None => return Err(StdError::NotFound { kind: format!("receiver {:?} not found", receiver_b) }),
+            None => {
+                return Err(StdError::NotFound {
+                    kind: format!("receiver {:?} not found", receiver_b),
+                })
+            }
         };
         match self.receivers.get(&receiver_b) {
             Some(val) => new_receivers.insert(router_b, *val),
-            None => return Err(StdError::NotFound { kind: format!("receiver {:?} not found", receiver_b) }),
+            None => {
+                return Err(StdError::NotFound {
+                    kind: format!("receiver {:?} not found", receiver_b),
+                })
+            }
         };
 
-        Ok(SplitConfig { receivers: new_receivers })
+        Ok(SplitConfig {
+            receivers: new_receivers,
+        })
     }
 
     pub fn validate(&self, party_a: &str, party_b: &str) -> Result<(), StdError> {
@@ -232,7 +240,7 @@ impl SplitConfig {
         if share_a + share_b != Decimal::one() {
             return Err(StdError::generic_err(
                 "shares must add up to 1.0".to_string(),
-            ))
+            ));
         }
 
         Ok(())
@@ -259,7 +267,7 @@ impl SplitConfig {
                         } else {
                             (addr, Decimal::zero())
                         }
-                    },
+                    }
                     None => (addr, *share),
                 }
             })
@@ -606,12 +614,13 @@ pub fn query_astro_pool_token(
 
     let liquidity_token_balance: BalanceResponse = querier.query_wasm_smart(
         pair_info.liquidity_token.as_ref(),
-        &cw20::Cw20QueryMsg::Balance {
-            address: addr,
-        },
+        &cw20::Cw20QueryMsg::Balance { address: addr },
     )?;
 
-    Ok(AstroportPoolTokenResponse { pair_info, balance_response: liquidity_token_balance })
+    Ok(AstroportPoolTokenResponse {
+        pair_info,
+        balance_response: liquidity_token_balance,
+    })
 }
 
 #[cw_serde]

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -1,13 +1,16 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, io::Stderr};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     Addr, Attribute, BankMsg, BlockInfo, Coin, CosmosMsg, Decimal, Fraction, IbcMsg, IbcTimeout,
-    StdError, Timestamp, Uint128, Uint64,
+    StdError, Timestamp, Uint128, Uint64, QuerierWrapper,
 };
+use cw20::BalanceResponse;
 use neutron_sdk::{
     bindings::msg::{IbcFee, NeutronMsg},
     sudo::msg::RequestPacketTimeoutHeight,
 };
+use astroport::asset::PairInfo;
+
 
 pub mod neutron_ica {
     use cosmwasm_schema::{cw_serde, QueryResponses};
@@ -566,4 +569,53 @@ impl DestinationConfig {
             Attribute::new("ibc_transfer_timeout", self.ibc_transfer_timeout),
         ]
     }
+}
+
+/// queries the liquidity token balance of given address
+pub fn query_liquidity_token_balance(
+    querier: QuerierWrapper,
+    liquidity_token: &str,
+    contract_addr: String,
+) -> Result<Uint128, StdError> {
+    let liquidity_token_balance: BalanceResponse = querier.query_wasm_smart(
+        liquidity_token,
+        &cw20::Cw20QueryMsg::Balance {
+            address: contract_addr,
+        },
+    )?;
+    Ok(liquidity_token_balance.balance)
+}
+
+/// queries the cw20 liquidity token address corresponding to a given pool
+pub fn query_liquidity_token_address(
+    querier: QuerierWrapper,
+    pool: String,
+) -> Result<String, StdError> {
+    let pair_info: PairInfo =
+        querier.query_wasm_smart(pool, &astroport::pair::QueryMsg::Pair {})?;
+    Ok(pair_info.liquidity_token.to_string())
+}
+
+pub fn query_astro_pool_token(
+    querier: QuerierWrapper,
+    pool: String,
+    addr: String,
+) -> Result<AstroportPoolTokenResponse, StdError> {
+    let pair_info: PairInfo =
+        querier.query_wasm_smart(pool, &astroport::pair::QueryMsg::Pair {})?;
+
+    let liquidity_token_balance: BalanceResponse = querier.query_wasm_smart(
+        pair_info.liquidity_token.as_ref(),
+        &cw20::Cw20QueryMsg::Balance {
+            address: addr,
+        },
+    )?;
+
+    Ok(AstroportPoolTokenResponse { pair_info, balance_response: liquidity_token_balance })
+}
+
+#[cw_serde]
+pub struct AstroportPoolTokenResponse {
+    pub pair_info: PairInfo,
+    pub balance_response: BalanceResponse,
 }

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    Addr, Attribute, BankMsg, BlockInfo, Coin, CosmosMsg, IbcMsg, IbcTimeout, StdError, Timestamp,
-    Uint128, Uint64, StdResult,
+    Addr, Attribute, BankMsg, BlockInfo, Coin, CosmosMsg, IbcMsg, IbcTimeout, StdError, StdResult,
+    Timestamp, Uint128, Uint64,
 };
 use neutron_sdk::{
     bindings::msg::{IbcFee, NeutronMsg},
@@ -167,14 +167,12 @@ pub mod neutron_ica {
     }
 }
 
-
 // splitter
 #[cw_serde]
 pub struct DenomSplit {
     pub denom: String,
     pub split: SplitType,
 }
-
 
 #[cw_serde]
 pub enum SplitType {
@@ -239,7 +237,9 @@ impl SplitConfig {
         if total_share == Uint128::new(100) {
             Ok(self)
         } else {
-            Err(StdError::GenericErr { msg: "shares must add up to 100".to_string() })
+            Err(StdError::GenericErr {
+                msg: "shares must add up to 100".to_string(),
+            })
         }
     }
 
@@ -253,7 +253,9 @@ impl SplitConfig {
         for receiver in self.receivers.iter() {
             let entitlement = amount
                 .checked_multiply_ratio(receiver.share, Uint128::new(100))
-                .map_err(|_| StdError::GenericErr { msg: "failed to checked_multiply".to_string() })?;
+                .map_err(|_| StdError::GenericErr {
+                    msg: "failed to checked_multiply".to_string(),
+                })?;
 
             let amount = Coin {
                 denom: denom.to_string(),
@@ -281,7 +283,6 @@ impl SplitConfig {
         Attribute::new(denom, receivers)
     }
 }
-
 
 pub fn get_distribution_messages(
     mut balances: Vec<Coin>,

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -9,7 +9,7 @@ use neutron_sdk::{
     bindings::msg::{IbcFee, NeutronMsg},
     sudo::msg::RequestPacketTimeoutHeight,
 };
-use std::{collections::BTreeMap, io::Stderr};
+use std::collections::BTreeMap;
 
 pub mod neutron_ica {
     use cosmwasm_schema::{cw_serde, QueryResponses};
@@ -289,14 +289,14 @@ impl SplitConfig {
             })
             .collect();
 
-        Ok(msgs?)
+        msgs
     }
 
     pub fn get_response_attribute(&self, denom: String) -> Attribute {
         let mut receivers = "[".to_string();
         self.receivers.iter().for_each(|(receiver, share)| {
             receivers.push('(');
-            receivers.push_str(&receiver);
+            receivers.push_str(receiver);
             receivers.push(':');
             receivers.push_str(&share.to_string());
             receivers.push_str("),");

--- a/packages/cw-fifo/src/lib.rs
+++ b/packages/cw-fifo/src/lib.rs
@@ -63,9 +63,10 @@ where
             .mapping
             .range(storage, None, None, cosmwasm_std::Order::Ascending)
             .next()
-            .transpose()? else {
-		return Ok(None)
-	    };
+            .transpose()?
+        else {
+            return Ok(None);
+        };
         self.mapping.remove(storage, time)?;
         Ok(Some(t))
     }

--- a/two-party-pol-covenant/tests/interchaintest/connection_helpers.go
+++ b/two-party-pol-covenant/tests/interchaintest/connection_helpers.go
@@ -211,10 +211,14 @@ func (testCtx *TestContext) holderRagequit(contract string, from *ibc.Wallet, ke
 	require.NoError(testCtx.t, err, "ragequit failed")
 }
 
-func (testCtx *TestContext) manualInstantiate(codeId string, msg string, from *ibc.Wallet, keyring string) string {
+func (testCtx *TestContext) manualInstantiate(codeId string, msg CovenantInstantiateMsg, from *ibc.Wallet, keyring string) string {
+
+	str, err := json.Marshal(msg)
+	require.NoError(testCtx.t, err, "Failed to marshall CovenantInstantiateMsg")
+	instantiateMsg := string(str)
 
 	cmd := []string{"neutrond", "tx", "wasm", "instantiate", codeId,
-		msg,
+		instantiateMsg,
 		"--label", fmt.Sprintf("two-party-pol-covenant-%s", codeId),
 		"--no-admin",
 		"--from", from.KeyName,
@@ -226,9 +230,12 @@ func (testCtx *TestContext) manualInstantiate(codeId string, msg string, from *i
 		"--keyring-backend", keyring,
 		"-y",
 	}
-	println("insantiating with cmd: ", strings.Join(cmd, " "))
 
-	_, _, err := testCtx.Neutron.Exec(testCtx.ctx, cmd, nil)
+	prettyJson, _ := json.MarshalIndent(msg, "", "    ")
+	println("covenant instantiation message:")
+	fmt.Println(string(prettyJson))
+
+	_, _, err = testCtx.Neutron.Exec(testCtx.ctx, cmd, nil)
 	require.NoError(testCtx.t, err, "manual instantiation failed")
 
 	require.NoError(testCtx.t,

--- a/two-party-pol-covenant/tests/interchaintest/connection_helpers.go
+++ b/two-party-pol-covenant/tests/interchaintest/connection_helpers.go
@@ -226,7 +226,7 @@ func (testCtx *TestContext) manualInstantiate(codeId string, msg CovenantInstant
 		"--home", testCtx.Neutron.HomeDir(),
 		"--node", testCtx.Neutron.GetRPCAddress(),
 		"--chain-id", testCtx.Neutron.Config().ChainID,
-		"--gas", "90009000",
+		"--gas", "900090000",
 		"--keyring-backend", keyring,
 		"-y",
 	}

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -506,8 +506,8 @@ func TestTwoPartyPol(t *testing.T) {
 
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
-				depositBlock := Block(currentHeight + 200)
-				lockupBlock := Block(currentHeight + 300)
+				depositBlock := Block(currentHeight + 100)
+				lockupBlock := Block(currentHeight + 200)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,
@@ -598,15 +598,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronAtomIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: hubReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: osmoReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "0.5",
+										osmoReceiverAddr: "0.5",
 									},
 								},
 							},
@@ -615,15 +609,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronOsmoIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: osmoReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: hubReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "0.5",
+										osmoReceiverAddr: "0.5",
 									},
 								},
 							},
@@ -766,12 +754,16 @@ func TestTwoPartyPol(t *testing.T) {
 			t.Run("party A claims and router receives the funds", func(t *testing.T) {
 				for {
 					routerAtomBalA, _ := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
+					routerOsmoBalA, _ := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronOsmoIbcDenom)
+					routerAtomBalB, _ := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronAtomIbcDenom)
 					routerOsmoBalB, _ := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronOsmoIbcDenom)
 
 					println("routerAtomBalA: ", routerAtomBalA)
+					println("routerOsmoBalA: ", routerOsmoBalA)
+					println("routerAtomBalB: ", routerAtomBalB)
 					println("routerOsmoBalB: ", routerOsmoBalB)
 
-					if routerAtomBalA != 0 && routerOsmoBalB != 0 {
+					if routerAtomBalA != 0 && routerOsmoBalA != 0 {
 						break
 					} else {
 						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
@@ -782,20 +774,15 @@ func TestTwoPartyPol(t *testing.T) {
 
 			t.Run("tick until party A claim is distributed", func(t *testing.T) {
 				for {
-					osmoBalPartyB, _ := cosmosOsmosis.GetBalance(
-						ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom)
-
 					atomBalPartyA, _ := cosmosAtom.GetBalance(
 						ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom)
-
-					atomBalPartyB, _ := cosmosOsmosis.GetBalance(
-						ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom)
+					osmoBalPartyA, _ := cosmosAtom.GetBalance(
+						ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom)
 
 					println("party A atom bal: ", atomBalPartyA)
-					println("party B osmo bal: ", osmoBalPartyB)
-					println("party B atom bal: ", atomBalPartyB)
+					println("party A osmo bal: ", osmoBalPartyA)
 
-					if atomBalPartyA != 0 && osmoBalPartyB != 0 {
+					if atomBalPartyA != 0 && osmoBalPartyA != 0 {
 						break
 					} else {
 						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
@@ -812,7 +799,7 @@ func TestTwoPartyPol(t *testing.T) {
 					println("routerAtomBalB: ", routerAtomBalB)
 					println("routerOsmoBalB: ", routerOsmoBalB)
 
-					if routerAtomBalB != 0 || routerOsmoBalB != 0 {
+					if routerAtomBalB != 0 && routerOsmoBalB != 0 {
 						break
 					} else {
 						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
@@ -844,7 +831,7 @@ func TestTwoPartyPol(t *testing.T) {
 			})
 		})
 
-		t.Run("two party POL ragequit path", func(t *testing.T) {
+		t.Run("two party share based POL ragequit path", func(t *testing.T) {
 
 			t.Run("instantiate covenant", func(t *testing.T) {
 				timeouts := Timeouts{
@@ -854,8 +841,8 @@ func TestTwoPartyPol(t *testing.T) {
 
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
-				depositBlock := Block(currentHeight + 200)
-				lockupBlock := Block(currentHeight + 300)
+				depositBlock := Block(currentHeight + 100)
+				lockupBlock := Block(currentHeight + 200)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,
@@ -944,15 +931,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronAtomIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: hubReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: osmoReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "0.5",
+										osmoReceiverAddr: "0.5",
 									},
 								},
 							},
@@ -961,15 +942,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronOsmoIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: osmoReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: hubReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "0.5",
+										osmoReceiverAddr: "0.5",
 									},
 								},
 							},
@@ -1194,8 +1169,8 @@ func TestTwoPartyPol(t *testing.T) {
 
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
-				depositBlock := Block(currentHeight + 200)
-				lockupBlock := Block(currentHeight + 300)
+				depositBlock := Block(currentHeight + 100)
+				lockupBlock := Block(currentHeight + 200)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,
@@ -1284,15 +1259,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronAtomIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: hubReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: osmoReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "1.0",
+										osmoReceiverAddr: "0.0",
 									},
 								},
 							},
@@ -1301,15 +1270,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronOsmoIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: osmoReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: hubReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "0.0",
+										osmoReceiverAddr: "1.0",
 									},
 								},
 							},
@@ -1585,15 +1548,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronAtomIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: hubReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: osmoReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "1.0",
+										osmoReceiverAddr: "0.0",
 									},
 								},
 							},
@@ -1602,15 +1559,9 @@ func TestTwoPartyPol(t *testing.T) {
 							Denom: neutronOsmoIbcDenom,
 							Type: SplitType{
 								Custom: SplitConfig{
-									Receivers: []Receiver{
-										{
-											Address: osmoReceiverAddr,
-											Share:   "1.0",
-										},
-										{
-											Address: hubReceiverAddr,
-											Share:   "0.0",
-										},
+									Receivers: map[string]string{
+										hubReceiverAddr:  "0.0",
+										osmoReceiverAddr: "1.0",
 									},
 								},
 							},

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -1418,6 +1418,35 @@ func TestTwoPartyPol(t *testing.T) {
 					ExpectedPoolRatio:        "0.1",
 					AcceptablePoolRatioDelta: "0.09",
 					PairType:                 pairType,
+					Splits: []DenomSplit{
+						{
+							Denom: neutronAtomIbcDenom,
+							Type: SplitType{
+								Custom: SplitConfig{
+									Receivers: []Receiver{
+										{
+											Address: gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix),
+											Share:   "100",
+										},
+									},
+								},
+							},
+						},
+						{
+							Denom: neutronOsmoIbcDenom,
+							Type: SplitType{
+								Custom: SplitConfig{
+									Receivers: []Receiver{
+										{
+											Address: osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
+											Share:   "100",
+										},
+									},
+								},
+							},
+						},
+					},
+					FallbackSplit: nil,
 				}
 				str, err := json.Marshal(covenantMsg)
 				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
@@ -1782,7 +1811,7 @@ func TestTwoPartyPol(t *testing.T) {
 					println("routerAtomBalA: ", routerAtomBalA)
 					println("routerOsmoBalA: ", routerOsmoBalA)
 
-					if routerAtomBalA != 0 && routerOsmoBalA != 0 {
+					if routerAtomBalA != 0 {
 						break
 					} else {
 						tickClock()
@@ -1828,7 +1857,7 @@ func TestTwoPartyPol(t *testing.T) {
 					println("routerAtomBalB: ", routerAtomBalB)
 					println("routerOsmoBalB: ", routerOsmoBalB)
 
-					if routerAtomBalB != 0 || routerOsmoBalB != 0 {
+					if routerOsmoBalB != 0 {
 						break
 					} else {
 						tickClock()
@@ -1863,7 +1892,7 @@ func TestTwoPartyPol(t *testing.T) {
 					println("party B osmo bal: ", osmoBalPartyB)
 					println("party B atom bal: ", atomBalPartyB)
 
-					if osmoBalPartyA != 0 && atomBalPartyA != 0 && osmoBalPartyB != 0 && atomBalPartyB != 0 {
+					if atomBalPartyA != 0 && osmoBalPartyB != 0 && atomBalPartyB != 0 {
 						break
 					}
 

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -506,7 +506,7 @@ func TestTwoPartyPol(t *testing.T) {
 
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
-				depositBlock := Block(currentHeight + 100)
+				depositBlock := Block(currentHeight + 150)
 				lockupBlock := Block(currentHeight + 200)
 
 				lockupConfig := Expiration{
@@ -576,6 +576,31 @@ func TestTwoPartyPol(t *testing.T) {
 					Stable: struct{}{},
 				}
 
+				denomSplits := []DenomSplit{
+					{
+						Denom: neutronAtomIbcDenom,
+						Type: SplitType{
+							Custom: SplitConfig{
+								Receivers: map[string]string{
+									hubReceiverAddr:  "0.5",
+									osmoReceiverAddr: "0.5",
+								},
+							},
+						},
+					},
+					{
+						Denom: neutronOsmoIbcDenom,
+						Type: SplitType{
+							Custom: SplitConfig{
+								Receivers: map[string]string{
+									hubReceiverAddr:  "0.5",
+									osmoReceiverAddr: "0.5",
+								},
+							},
+						},
+					},
+				}
+
 				covenantMsg := CovenantInstantiateMsg{
 					Label:                    "two-party-pol-covenant-happy",
 					Timeouts:                 timeouts,
@@ -593,31 +618,8 @@ func TestTwoPartyPol(t *testing.T) {
 					AcceptablePoolRatioDelta: "0.09",
 					CovenantType:             "share",
 					PairType:                 pairType,
-					Splits: []DenomSplit{
-						{
-							Denom: neutronAtomIbcDenom,
-							Type: SplitType{
-								Custom: SplitConfig{
-									Receivers: map[string]string{
-										hubReceiverAddr:  "0.5",
-										osmoReceiverAddr: "0.5",
-									},
-								},
-							},
-						},
-						{
-							Denom: neutronOsmoIbcDenom,
-							Type: SplitType{
-								Custom: SplitConfig{
-									Receivers: map[string]string{
-										hubReceiverAddr:  "0.5",
-										osmoReceiverAddr: "0.5",
-									},
-								},
-							},
-						},
-					},
-					FallbackSplit: nil,
+					Splits:                   denomSplits,
+					FallbackSplit:            nil,
 				}
 
 				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantCodeId, 10), covenantMsg, neutronUser, keyring.BackendTest)

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -286,6 +286,9 @@ func TestTwoPartyPol(t *testing.T) {
 	rqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
 	rqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
 
+	// sideBasedRqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
+	// sideBasedRqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
+
 	happyCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
 	happyCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
 
@@ -838,13 +841,9 @@ func TestTwoPartyPol(t *testing.T) {
 					LiquidPoolerCode:     lperCodeId,
 				}
 
-				ragequitType := RagequitType{
-					Share: &Share{},
-				}
-
 				ragequitTerms := RagequitTerms{
 					Penalty:      "0.1",
-					RagequitType: ragequitType,
+					RagequitType: "share",
 				}
 
 				ragequitConfig := RagequitConfig{
@@ -1481,12 +1480,10 @@ func TestTwoPartyPol(t *testing.T) {
 					HolderCode:           holderCodeId,
 					LiquidPoolerCode:     lperCodeId,
 				}
-				ragequitType := RagequitType{
-					Share: &Share{},
-				}
+
 				ragequitTerms := RagequitTerms{
 					Penalty:      "0.1",
-					RagequitType: ragequitType,
+					RagequitType: "share",
 				}
 
 				ragequitConfig := RagequitConfig{

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -206,6 +206,9 @@ func TestTwoPartyPol(t *testing.T) {
 	require.NoError(t, err, "failed to wait for blocks")
 
 	testCtx := &TestContext{
+		Neutron:                   cosmosNeutron,
+		Hub:                       cosmosAtom,
+		Osmosis:                   cosmosOsmosis,
 		OsmoClients:               []*ibc.ClientOutput{},
 		GaiaClients:               []*ibc.ClientOutput{},
 		NeutronClients:            []*ibc.ClientOutput{},
@@ -217,6 +220,8 @@ func TestTwoPartyPol(t *testing.T) {
 		OsmoTransferChannelIds:    make(map[string]string),
 		GaiaIcsChannelIds:         make(map[string]string),
 		NeutronIcsChannelIds:      make(map[string]string),
+		t:                         t,
+		ctx:                       ctx,
 	}
 
 	t.Run("generate IBC paths", func(t *testing.T) {
@@ -286,8 +291,8 @@ func TestTwoPartyPol(t *testing.T) {
 	rqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
 	rqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
 
-	// sideBasedRqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
-	// sideBasedRqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
+	sideBasedRqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
+	sideBasedRqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
 
 	happyCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
 	happyCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
@@ -359,8 +364,11 @@ func TestTwoPartyPol(t *testing.T) {
 
 		var covenantRqCodeIdStr string
 		var covenantRqCodeId uint64
+		var covenantSideBasedRqCodeIdStr string
+		var covenantSideBasedRqCodeId uint64
 		_ = covenantCodeId
 		_ = covenantRqCodeId
+		_ = covenantSideBasedRqCodeId
 
 		queryLpTokenBalance := func(token string, addr string) string {
 			bal := Balance{
@@ -388,6 +396,11 @@ func TestTwoPartyPol(t *testing.T) {
 			covenantRqCodeIdStr, err = cosmosNeutron.StoreContract(ctx, neutronUser.KeyName, covenantContractPath)
 			require.NoError(t, err, "failed to store two party pol covenant contract")
 			covenantRqCodeId, err = strconv.ParseUint(covenantRqCodeIdStr, 10, 64)
+			require.NoError(t, err, "failed to parse codeId into uint64")
+
+			covenantSideBasedRqCodeIdStr, err = cosmosNeutron.StoreContract(ctx, neutronUser.KeyName, covenantContractPath)
+			require.NoError(t, err, "failed to store two party pol covenant contract")
+			covenantSideBasedRqCodeId, err = strconv.ParseUint(covenantSideBasedRqCodeIdStr, 10, 64)
 			require.NoError(t, err, "failed to parse codeId into uint64")
 
 			// store clock and get code id
@@ -754,30 +767,6 @@ func TestTwoPartyPol(t *testing.T) {
 
 		t.Run("two party POL happy path", func(t *testing.T) {
 
-			tickClock := func() {
-				println("\ntick")
-				cmd := []string{"neutrond", "tx", "wasm", "execute", clockAddress,
-					`{"tick":{}}`,
-					"--gas-prices", "0.0untrn",
-					"--gas-adjustment", `1.5`,
-					"--output", "json",
-					"--home", "/var/cosmos-chain/neutron-2",
-					"--node", neutron.GetRPCAddress(),
-					"--home", neutron.HomeDir(),
-					"--chain-id", neutron.Config().ChainID,
-					"--from", neutronUser.KeyName,
-					"--gas", "1500000",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-
-				resp, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
-				require.NoError(t, err)
-				println("tick response: ", string(resp), "\n")
-				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-				require.NoError(t, err, "failed to wait for blocks")
-			}
-
 			t.Run("instantiate covenant", func(t *testing.T) {
 				timeouts := Timeouts{
 					IcaTimeout:         "100", // sec
@@ -906,105 +895,32 @@ func TestTwoPartyPol(t *testing.T) {
 				instantiateMsg := string(str)
 
 				println("instantiation message: ", instantiateMsg)
-				cmd := []string{"neutrond", "tx", "wasm", "instantiate", covenantCodeIdStr,
-					instantiateMsg,
-					"--label", "two-party-pol-covenant-happy",
-					"--no-admin",
-					"--from", neutronUser.KeyName,
-					"--output", "json",
-					"--home", neutron.HomeDir(),
-					"--node", neutron.GetRPCAddress(),
-					"--chain-id", neutron.Config().ChainID,
-					"--gas", "90009000",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
 
-				_, _, err = neutron.Exec(ctx, cmd, nil)
-				require.NoError(t, err)
-				require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis))
-
-				queryCmd := []string{"neutrond", "query", "wasm",
-					"list-contract-by-code", covenantCodeIdStr,
-					"--output", "json",
-					"--home", neutron.HomeDir(),
-					"--node", neutron.GetRPCAddress(),
-					"--chain-id", neutron.Config().ChainID,
-				}
-
-				queryResp, _, err := neutron.Exec(ctx, queryCmd, nil)
-				require.NoError(t, err, "failed to query")
-
-				type QueryContractResponse struct {
-					Contracts  []string `json:"contracts"`
-					Pagination any      `json:"pagination"`
-				}
-
-				contactsRes := QueryContractResponse{}
-				require.NoError(t, json.Unmarshal(queryResp, &contactsRes), "failed to unmarshal contract response")
-
-				covenantAddress = contactsRes.Contracts[len(contactsRes.Contracts)-1]
+				covenantAddress = testCtx.manualInstantiate(covenantCodeIdStr, instantiateMsg, neutronUser, keyring.BackendTest)
 
 				println("covenant address: ", covenantAddress)
 			})
 
 			t.Run("query covenant contracts", func(t *testing.T) {
-				routerQueryPartyA := InterchainRouterQuery{
-					Party: Party{
-						Party: "party_a",
-					},
-				}
-				routerQueryPartyB := InterchainRouterQuery{
-					Party: Party{
-						Party: "party_b",
-					},
-				}
-				forwarderQueryPartyA := IbcForwarderQuery{
-					Party: Party{
-						Party: "party_a",
-					},
-				}
-				forwarderQueryPartyB := IbcForwarderQuery{
-					Party: Party{
-						Party: "party_b",
-					},
-				}
-
-				var response CovenantAddressQueryResponse
-
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, ClockAddressQuery{}, &response)
-				require.NoError(t, err, "failed to query instantiated clock address")
-				clockAddress = response.Data
+				clockAddress = testCtx.queryClockAddress(covenantAddress)
 				println("clock addr: ", clockAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, HolderAddressQuery{}, &response)
-				require.NoError(t, err, "failed to query instantiated holder address")
-				holderAddress = response.Data
+				holderAddress = testCtx.queryHolderAddress(covenantAddress)
 				println("holder addr: ", holderAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, LiquidPoolerQuery{}, &response)
-				require.NoError(t, err, "failed to query instantiated liquid pooler address")
-				liquidPoolerAddress = response.Data
+				liquidPoolerAddress = testCtx.queryLiquidPoolerAddress(covenantAddress)
 				println("liquid pooler addr: ", liquidPoolerAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyA, &response)
-				require.NoError(t, err, "failed to query instantiated party a router address")
-				partyARouterAddress = response.Data
+				partyARouterAddress = testCtx.queryInterchainRouterAddress(covenantAddress, "party_a")
 				println("partyARouterAddress: ", partyARouterAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyB, &response)
-				require.NoError(t, err, "failed to query instantiated party b router address")
-				partyBRouterAddress = response.Data
+				partyBRouterAddress = testCtx.queryInterchainRouterAddress(covenantAddress, "party_b")
 				println("partyBRouterAddress: ", partyBRouterAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyA, &response)
-				require.NoError(t, err, "failed to query instantiated party a forwarder address")
-				partyAIbcForwarderAddress = response.Data
+				partyAIbcForwarderAddress = testCtx.queryIbcForwarderAddress(covenantAddress, "party_a")
 				println("partyAIbcForwarderAddress: ", partyAIbcForwarderAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyB, &response)
-				require.NoError(t, err, "failed to query instantiated party b forwarder address")
-				partyBIbcForwarderAddress = response.Data
+				partyBIbcForwarderAddress = testCtx.queryIbcForwarderAddress(covenantAddress, "party_b")
 				println("partyBIbcForwarderAddress: ", partyBIbcForwarderAddress)
 			})
 
@@ -1075,48 +991,17 @@ func TestTwoPartyPol(t *testing.T) {
 			})
 
 			t.Run("tick until forwarders create ICA", func(t *testing.T) {
-				require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
+				require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis), "failed to wait for blocks")
 				for {
-					tickClock()
-					var response CovenantAddressQueryResponse
-					type ContractState struct{}
-					type ContractStateQuery struct {
-						ContractState ContractState `json:"contract_state"`
-					}
-					contractStateQuery := ContractStateQuery{
-						ContractState: ContractState{},
-					}
+					testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 
-					require.NoError(t,
-						cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, contractStateQuery, &response),
-						"failed to query forwarder A state")
-					forwarderAState := response.Data
-
-					require.NoError(t,
-						cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, contractStateQuery, &response),
-						"failed to query forwarder B state")
-					forwarderBState := response.Data
+					forwarderAState := testCtx.queryContractState(partyAIbcForwarderAddress)
+					forwarderBState := testCtx.queryContractState(partyBIbcForwarderAddress)
 
 					if forwarderAState == forwarderBState && forwarderBState == "ica_created" {
-						require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
-
-						var depositAddressResponse CovenantAddressQueryResponse
-
-						type DepositAddress struct{}
-						type DepositAddressQuery struct {
-							DepositAddress DepositAddress `json:"deposit_address"`
-						}
-						depositAddressQuery := DepositAddressQuery{
-							DepositAddress: DepositAddress{},
-						}
-
-						err := cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
-						require.NoError(t, err, "failed to query party a forwarder deposit address")
-						partyADepositAddress = depositAddressResponse.Data
-
-						err = cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
-						require.NoError(t, err, "failed to query party b forwarder deposit address")
-						partyBDepositAddress = depositAddressResponse.Data
+						require.NoError(t, testutil.WaitForBlocks(ctx, 3, atom, neutron, osmosis), "failed to wait for blocks")
+						partyADepositAddress = testCtx.queryDepositAddress(partyAIbcForwarderAddress)
+						partyBDepositAddress = testCtx.queryDepositAddress(partyBIbcForwarderAddress)
 						println("both parties icas created: ", partyADepositAddress, " , ", partyBDepositAddress)
 						break
 					}
@@ -1155,33 +1040,17 @@ func TestTwoPartyPol(t *testing.T) {
 					require.NoError(t, err, "failed to query holder osmo bal")
 					holderAtomBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronAtomIbcDenom)
 					require.NoError(t, err, "failed to query holder atom bal")
-					// liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
-					// require.NoError(t, err, "failed to query liquidPooler osmo bal")
-					// liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
-					// require.NoError(t, err, "failed to query liquidPooler atom bal")
 					println("holder atom bal: ", holderAtomBal)
 					println("holder osmo bal: ", holderOsmoBal)
 
-					var response CovenantAddressQueryResponse
-					type ContractState struct{}
-					type ContractStateQuery struct {
-						ContractState ContractState `json:"contract_state"`
-					}
-					contractStateQuery := ContractStateQuery{
-						ContractState: ContractState{},
-					}
-
-					require.NoError(t,
-						cosmosNeutron.QueryContract(ctx, holderAddress, contractStateQuery, &response),
-						"failed to query holder state")
-					holderState := response.Data
+					holderState := testCtx.queryContractState(holderAddress)
 					println("holder state: ", holderState)
 
 					if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) || holderState == "active" {
 						println("\nholder/liquidpooler received atom & osmo\n")
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
@@ -1201,7 +1070,7 @@ func TestTwoPartyPol(t *testing.T) {
 					if liquidPoolerOsmoBal == int64(osmoContributionAmount) && liquidPoolerAtomBal == int64(atomContributionAmount) {
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
@@ -1216,7 +1085,7 @@ func TestTwoPartyPol(t *testing.T) {
 					}
 
 					if holderLpBal == 0 {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					} else {
 						break
 					}
@@ -1232,28 +1101,12 @@ func TestTwoPartyPol(t *testing.T) {
 						println("neutron height: ", neutronHeight)
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
 
 			t.Run("party A claims and router receives the funds", func(t *testing.T) {
-
-				cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
-					`{"claim":{}}`,
-					"--from", hubNeutronAccount.GetKeyName(),
-					"--gas-prices", "0.0untrn",
-					"--gas-adjustment", `1.5`,
-					"--output", "json",
-					"--node", neutron.GetRPCAddress(),
-					"--home", neutron.HomeDir(),
-					"--chain-id", neutron.Config().ChainID,
-					"--gas", "42069420",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-				println("hub claim msg: ", strings.Join(cmd, " "))
-
 				for {
 					routerAtomBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
 					require.NoError(t, err)
@@ -1267,9 +1120,9 @@ func TestTwoPartyPol(t *testing.T) {
 					if routerAtomBalA != 0 && routerOsmoBalB != 0 {
 						break
 					} else {
-						tickClock()
-						_, _, err = cosmosNeutron.Exec(ctx, cmd, nil)
-						require.NoError(t, err, "party A claim failed")
+
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+						testCtx.holderClaim(holderAddress, hubNeutronAccount, keyring.BackendTest)
 
 						err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
 						require.NoError(t, err, "failed to wait for blocks")
@@ -1309,30 +1162,14 @@ func TestTwoPartyPol(t *testing.T) {
 						break
 					} else {
 						i = i - 1
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
 
 			t.Run("party B claims and router receives the funds", func(t *testing.T) {
 
-				cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
-					`{"claim":{}}`,
-					"--from", osmoNeutronAccount.GetKeyName(),
-					"--gas-prices", "0.0untrn",
-					"--gas-adjustment", `1.8`,
-					"--output", "json",
-					"--node", neutron.GetRPCAddress(),
-					"--home", neutron.HomeDir(),
-					"--chain-id", neutron.Config().ChainID,
-					"--gas", "42069420",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-
-				println("osmo claim msg: ", strings.Join(cmd, " "))
-				_, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
-				require.NoError(t, err, "party B claim failed")
+				testCtx.holderClaim(holderAddress, osmoNeutronAccount, keyring.BackendTest)
 
 				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
 				require.NoError(t, err, "failed to wait for blocks")
@@ -1350,7 +1187,7 @@ func TestTwoPartyPol(t *testing.T) {
 					if routerAtomBalB != 0 || routerOsmoBalB != 0 {
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
@@ -1386,37 +1223,12 @@ func TestTwoPartyPol(t *testing.T) {
 						break
 					}
 
-					tickClock()
+					testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 				}
 			})
 		})
 
 		t.Run("two party POL ragequit path", func(t *testing.T) {
-
-			tickClock := func() {
-				currentHeight, _ := cosmosNeutron.Height(ctx)
-				println("\ntick @ height ", currentHeight)
-				cmd := []string{"neutrond", "tx", "wasm", "execute", clockAddress,
-					`{"tick":{}}`,
-					"--gas-prices", "0.0untrn",
-					"--gas-adjustment", `1.5`,
-					"--output", "json",
-					"--home", "/var/cosmos-chain/neutron-2",
-					"--node", neutron.GetRPCAddress(),
-					"--home", neutron.HomeDir(),
-					"--chain-id", neutron.Config().ChainID,
-					"--from", neutronUser.KeyName,
-					"--gas", "1500000",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-
-				resp, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
-				require.NoError(t, err)
-				println("tick response: ", string(resp), "\n")
-				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-				require.NoError(t, err, "failed to wait for blocks")
-			}
 
 			t.Run("instantiate covenant", func(t *testing.T) {
 				timeouts := Timeouts{
@@ -1545,109 +1357,30 @@ func TestTwoPartyPol(t *testing.T) {
 				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
 				instantiateMsg := string(str)
 
-				cmd := []string{"neutrond", "tx", "wasm", "instantiate", covenantRqCodeIdStr,
-					instantiateMsg,
-					"--label", "two-party-pol-covenant-ragequit",
-					"--no-admin",
-					"--from", neutronUser.KeyName,
-					"--output", "json",
-					"--home", neutron.HomeDir(),
-					"--node", neutron.GetRPCAddress(),
-					"--chain-id", neutron.Config().ChainID,
-					"--gas", "90009000",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-
-				println("instantiation cmd: ", strings.Join(cmd, " "))
-
-				_, stderr, err := neutron.Exec(ctx, cmd, nil)
-				println("\ninstantiation stderr: ", string(stderr), "\n")
-				require.NoError(t, err)
-				require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis))
-
-				queryCmd := []string{"neutrond", "query", "wasm",
-					"list-contract-by-code", covenantRqCodeIdStr,
-					"--output", "json",
-					"--home", neutron.HomeDir(),
-					"--node", neutron.GetRPCAddress(),
-					"--chain-id", neutron.Config().ChainID,
-				}
-				println("query cmd: \n ", strings.Join(queryCmd, " "))
-				queryResp, _, err := neutron.Exec(ctx, queryCmd, nil)
-				require.NoError(t, err, "failed to query")
-
-				type QueryContractResponse struct {
-					Contracts  []string `json:"contracts"`
-					Pagination any      `json:"pagination"`
-				}
-
-				contractsRes := QueryContractResponse{}
-				require.NoError(t, json.Unmarshal(queryResp, &contractsRes), "failed to unmarshal contract response")
-
-				println("contracts  response: ", strings.Join(contractsRes.Contracts, " "))
-				covenantAddress = contractsRes.Contracts[len(contractsRes.Contracts)-1]
-
+				covenantAddress = testCtx.manualInstantiate(covenantRqCodeIdStr, instantiateMsg, neutronUser, keyring.BackendTest)
 				println("covenant address: ", covenantAddress)
 			})
 
 			t.Run("query covenant contracts", func(t *testing.T) {
-				routerQueryPartyA := InterchainRouterQuery{
-					Party: Party{
-						Party: "party_a",
-					},
-				}
-				routerQueryPartyB := InterchainRouterQuery{
-					Party: Party{
-						Party: "party_b",
-					},
-				}
-				forwarderQueryPartyA := IbcForwarderQuery{
-					Party: Party{
-						Party: "party_a",
-					},
-				}
-				forwarderQueryPartyB := IbcForwarderQuery{
-					Party: Party{
-						Party: "party_b",
-					},
-				}
-
-				var response CovenantAddressQueryResponse
-
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, ClockAddressQuery{}, &response)
-				require.NoError(t, err, "failed to query instantiated clock address")
-				clockAddress = response.Data
+				clockAddress = testCtx.queryClockAddress(covenantAddress)
 				println("clock addr: ", clockAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, HolderAddressQuery{}, &response)
-				require.NoError(t, err, "failed to query instantiated holder address")
-				holderAddress = response.Data
+				holderAddress = testCtx.queryHolderAddress(covenantAddress)
 				println("holder addr: ", holderAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, LiquidPoolerQuery{}, &response)
-				require.NoError(t, err, "failed to query instantiated liquid pooler address")
-				liquidPoolerAddress = response.Data
+				liquidPoolerAddress = testCtx.queryLiquidPoolerAddress(covenantAddress)
 				println("liquid pooler addr: ", liquidPoolerAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyA, &response)
-				require.NoError(t, err, "failed to query instantiated party a router address")
-				partyARouterAddress = response.Data
+				partyARouterAddress = testCtx.queryInterchainRouterAddress(covenantAddress, "party_a")
 				println("partyARouterAddress: ", partyARouterAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyB, &response)
-				require.NoError(t, err, "failed to query instantiated party b router address")
-				partyBRouterAddress = response.Data
+				partyBRouterAddress = testCtx.queryInterchainRouterAddress(covenantAddress, "party_b")
 				println("partyBRouterAddress: ", partyBRouterAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyA, &response)
-				require.NoError(t, err, "failed to query instantiated party a forwarder address")
-				partyAIbcForwarderAddress = response.Data
+				partyAIbcForwarderAddress = testCtx.queryIbcForwarderAddress(covenantAddress, "party_a")
 				println("partyAIbcForwarderAddress: ", partyAIbcForwarderAddress)
 
-				err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyB, &response)
-				require.NoError(t, err, "failed to query instantiated party b forwarder address")
-				partyBIbcForwarderAddress = response.Data
+				partyBIbcForwarderAddress = testCtx.queryIbcForwarderAddress(covenantAddress, "party_b")
 				println("partyBIbcForwarderAddress: ", partyBIbcForwarderAddress)
 			})
 
@@ -1720,46 +1453,16 @@ func TestTwoPartyPol(t *testing.T) {
 			t.Run("tick until forwarders create ICA", func(t *testing.T) {
 				require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
 				for {
-					tickClock()
-					var response CovenantAddressQueryResponse
-					type ContractState struct{}
-					type ContractStateQuery struct {
-						ContractState ContractState `json:"contract_state"`
-					}
-					contractStateQuery := ContractStateQuery{
-						ContractState: ContractState{},
-					}
+					testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 
-					require.NoError(t,
-						cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, contractStateQuery, &response),
-						"failed to query forwarder A state")
-					forwarderAState := response.Data
-
-					require.NoError(t,
-						cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, contractStateQuery, &response),
-						"failed to query forwarder B state")
-					forwarderBState := response.Data
+					forwarderAState := testCtx.queryContractState(partyAIbcForwarderAddress)
+					forwarderBState := testCtx.queryContractState(partyBIbcForwarderAddress)
 
 					if forwarderAState == forwarderBState && forwarderBState == "ica_created" {
-						require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
+						require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis), "failed to wait for blocks")
 
-						var depositAddressResponse CovenantAddressQueryResponse
-
-						type DepositAddress struct{}
-						type DepositAddressQuery struct {
-							DepositAddress DepositAddress `json:"deposit_address"`
-						}
-						depositAddressQuery := DepositAddressQuery{
-							DepositAddress: DepositAddress{},
-						}
-
-						err := cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
-						require.NoError(t, err, "failed to query party a forwarder deposit address")
-						partyADepositAddress = depositAddressResponse.Data
-
-						err = cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
-						require.NoError(t, err, "failed to query party b forwarder deposit address")
-						partyBDepositAddress = depositAddressResponse.Data
+						partyADepositAddress = testCtx.queryDepositAddress(partyAIbcForwarderAddress)
+						partyBDepositAddress = testCtx.queryDepositAddress(partyBIbcForwarderAddress)
 						println("both parties icas created: ", partyADepositAddress, " , ", partyBDepositAddress)
 						break
 					}
@@ -1805,26 +1508,14 @@ func TestTwoPartyPol(t *testing.T) {
 					println("holder atom bal: ", holderAtomBal)
 					println("holder osmo bal: ", holderOsmoBal)
 
-					var response CovenantAddressQueryResponse
-					type ContractState struct{}
-					type ContractStateQuery struct {
-						ContractState ContractState `json:"contract_state"`
-					}
-					contractStateQuery := ContractStateQuery{
-						ContractState: ContractState{},
-					}
-
-					require.NoError(t,
-						cosmosNeutron.QueryContract(ctx, holderAddress, contractStateQuery, &response),
-						"failed to query holder state")
-					holderState := response.Data
+					holderState := testCtx.queryContractState(holderAddress)
 					println("holder state: ", holderState)
 
 					if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) || holderState == "active" {
 						println("\nholder/liquidpooler received atom & osmo\n")
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
@@ -1844,7 +1535,7 @@ func TestTwoPartyPol(t *testing.T) {
 					if liquidPoolerOsmoBal == int64(osmoContributionAmount) && liquidPoolerAtomBal == int64(atomContributionAmount) {
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
@@ -1859,44 +1550,14 @@ func TestTwoPartyPol(t *testing.T) {
 					}
 
 					if holderLpBal == 0 {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					} else {
 						break
-					}
-				}
-			})
-
-			t.Run("tick a bit", func(t *testing.T) {
-				for {
-					neutronHeight, err := cosmosNeutron.Height(ctx)
-					require.NoError(t, err)
-
-					if neutronHeight >= 500 {
-						println("neutron height: ", neutronHeight)
-						break
-					} else {
-						tickClock()
 					}
 				}
 			})
 
 			t.Run("party A ragequits", func(t *testing.T) {
-
-				cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
-					`{"ragequit":{}}`,
-					"--from", hubNeutronAccount.GetKeyName(),
-					"--gas-prices", "0.0untrn",
-					"--gas-adjustment", `1.5`,
-					"--output", "json",
-					"--node", neutron.GetRPCAddress(),
-					"--home", neutron.HomeDir(),
-					"--chain-id", neutron.Config().ChainID,
-					"--gas", "42069420",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-				println("hub ragequit msg: ", strings.Join(cmd, " "))
-
 				for {
 					routerAtomBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
 					require.NoError(t, err)
@@ -1910,12 +1571,8 @@ func TestTwoPartyPol(t *testing.T) {
 					if routerAtomBalA != 0 {
 						break
 					} else {
-						tickClock()
-						_, _, err = cosmosNeutron.Exec(ctx, cmd, nil)
-						require.NoError(t, err, "party A claim failed")
-
-						err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-						require.NoError(t, err, "failed to wait for blocks")
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+						testCtx.holderRagequit(holderAddress, hubNeutronAccount, keyring.BackendTest)
 					}
 				}
 			})
@@ -1952,30 +1609,14 @@ func TestTwoPartyPol(t *testing.T) {
 						break
 					} else {
 						i = i - 1
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
 
 			t.Run("party B claims and router receives the funds", func(t *testing.T) {
 
-				cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
-					`{"claim":{}}`,
-					"--from", osmoNeutronAccount.GetKeyName(),
-					"--gas-prices", "0.0untrn",
-					"--gas-adjustment", `1.8`,
-					"--output", "json",
-					"--node", neutron.GetRPCAddress(),
-					"--home", neutron.HomeDir(),
-					"--chain-id", neutron.Config().ChainID,
-					"--gas", "42069420",
-					"--keyring-backend", keyring.BackendTest,
-					"-y",
-				}
-
-				println("osmo claim msg: ", strings.Join(cmd, " "))
-				_, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
-				require.NoError(t, err, "party B claim failed")
+				testCtx.holderClaim(holderAddress, osmoNeutronAccount, keyring.BackendTest)
 
 				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
 				require.NoError(t, err, "failed to wait for blocks")
@@ -1993,7 +1634,7 @@ func TestTwoPartyPol(t *testing.T) {
 					if routerOsmoBalB != 0 {
 						break
 					} else {
-						tickClock()
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 					}
 				}
 			})
@@ -2024,7 +1665,423 @@ func TestTwoPartyPol(t *testing.T) {
 						break
 					}
 
-					tickClock()
+					testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+				}
+			})
+		})
+
+		t.Run("two party POL side-based ragequit path", func(t *testing.T) {
+
+			t.Run("instantiate covenant", func(t *testing.T) {
+				timeouts := Timeouts{
+					IcaTimeout:         "100", // sec
+					IbcTransferTimeout: "100", // sec
+				}
+
+				currentHeight, err := cosmosNeutron.Height(ctx)
+				require.NoError(t, err, "failed to get neutron height")
+				depositBlock := Block(currentHeight + 200)
+				lockupBlock := Block(currentHeight + 300)
+
+				lockupConfig := Expiration{
+					AtHeight: &lockupBlock,
+				}
+				depositDeadline := Expiration{
+					AtHeight: &depositBlock,
+				}
+				presetIbcFee := PresetIbcFee{
+					AckFee:     "10000",
+					TimeoutFee: "10000",
+				}
+
+				atomCoin := Coin{
+					Denom:  cosmosAtom.Config().Denom,
+					Amount: strconv.FormatUint(atomContributionAmount, 10),
+				}
+
+				osmoCoin := Coin{
+					Denom:  cosmosOsmosis.Config().Denom,
+					Amount: strconv.FormatUint(osmoContributionAmount, 10),
+				}
+				hubReceiverAddr := sideBasedRqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix)
+				osmoReceiverAddr := sideBasedRqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix)
+				partyAConfig := CovenantPartyConfig{
+					ControllerAddr:            hubReceiverAddr,
+					HostAddr:                  hubNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
+					Contribution:              atomCoin,
+					IbcDenom:                  neutronAtomIbcDenom,
+					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
+					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
+					PartyReceiverAddr:         hubReceiverAddr,
+					PartyChainConnectionId:    neutronAtomIBCConnId,
+					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
+				}
+				partyBConfig := CovenantPartyConfig{
+					ControllerAddr:            osmoReceiverAddr,
+					HostAddr:                  osmoNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
+					Contribution:              osmoCoin,
+					IbcDenom:                  neutronOsmoIbcDenom,
+					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
+					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
+					PartyReceiverAddr:         osmoReceiverAddr,
+					PartyChainConnectionId:    neutronOsmosisIBCConnId,
+					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
+				}
+				codeIds := ContractCodeIds{
+					IbcForwarderCode:     ibcForwarderCodeId,
+					InterchainRouterCode: routerCodeId,
+					ClockCode:            clockCodeId,
+					HolderCode:           holderCodeId,
+					LiquidPoolerCode:     lperCodeId,
+				}
+
+				ragequitTerms := RagequitTerms{
+					Penalty:      "0.1",
+					RagequitType: "side",
+				}
+
+				ragequitConfig := RagequitConfig{
+					Enabled: &ragequitTerms,
+				}
+
+				poolAddress := stableswapAddress
+				pairType := PairType{
+					Stable: struct{}{},
+				}
+
+				covenantMsg := CovenantInstantiateMsg{
+					Label:                    "two-party-pol-covenant-side-ragequit",
+					Timeouts:                 timeouts,
+					PresetIbcFee:             presetIbcFee,
+					ContractCodeIds:          codeIds,
+					LockupConfig:             lockupConfig,
+					PartyAConfig:             partyAConfig,
+					PartyBConfig:             partyBConfig,
+					PoolAddress:              poolAddress,
+					RagequitConfig:           &ragequitConfig,
+					DepositDeadline:          depositDeadline,
+					PartyAShare:              "50",
+					PartyBShare:              "50",
+					ExpectedPoolRatio:        "0.1",
+					AcceptablePoolRatioDelta: "0.09",
+					PairType:                 pairType,
+					Splits: []DenomSplit{
+						{
+							Denom: neutronAtomIbcDenom,
+							Type: SplitType{
+								Custom: SplitConfig{
+									Receivers: []Receiver{
+										{
+											Address: hubReceiverAddr,
+											Share:   "1.0",
+										},
+									},
+								},
+							},
+						},
+						{
+							Denom: neutronOsmoIbcDenom,
+							Type: SplitType{
+								Custom: SplitConfig{
+									Receivers: []Receiver{
+										{
+											Address: osmoReceiverAddr,
+											Share:   "1.0",
+										},
+									},
+								},
+							},
+						},
+					},
+					FallbackSplit: nil,
+				}
+				str, err := json.Marshal(covenantMsg)
+				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
+				instantiateMsg := string(str)
+
+				covenantAddress = testCtx.manualInstantiate(covenantSideBasedRqCodeIdStr, instantiateMsg, neutronUser, keyring.BackendTest)
+				println("covenant address: ", covenantAddress)
+			})
+
+			t.Run("query covenant contracts", func(t *testing.T) {
+				clockAddress = testCtx.queryClockAddress(covenantAddress)
+				println("clock addr: ", clockAddress)
+
+				holderAddress = testCtx.queryHolderAddress(covenantAddress)
+				println("holder addr: ", holderAddress)
+
+				liquidPoolerAddress = testCtx.queryLiquidPoolerAddress(covenantAddress)
+				println("liquid pooler addr: ", liquidPoolerAddress)
+
+				partyARouterAddress = testCtx.queryInterchainRouterAddress(covenantAddress, "party_a")
+				println("partyARouterAddress: ", partyARouterAddress)
+
+				partyBRouterAddress = testCtx.queryInterchainRouterAddress(covenantAddress, "party_b")
+				println("partyBRouterAddress: ", partyBRouterAddress)
+
+				partyAIbcForwarderAddress = testCtx.queryIbcForwarderAddress(covenantAddress, "party_a")
+				println("partyAIbcForwarderAddress: ", partyAIbcForwarderAddress)
+
+				partyBIbcForwarderAddress = testCtx.queryIbcForwarderAddress(covenantAddress, "party_b")
+				println("partyBIbcForwarderAddress: ", partyBIbcForwarderAddress)
+			})
+
+			t.Run("fund contracts with neutron", func(t *testing.T) {
+				err := neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyAIbcForwarderAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to partyAIbcForwarder contract")
+
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyBIbcForwarderAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to partyBIbcForwarder contract")
+
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: clockAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to clock contract")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyARouterAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to party a router")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyBRouterAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to party b router")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: holderAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to holder")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: liquidPoolerAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to holder")
+
+				err = testutil.WaitForBlocks(ctx, 2, atom, neutron, osmosis)
+				require.NoError(t, err, "failed to wait for blocks")
+
+				bal, err := neutron.GetBalance(ctx, partyAIbcForwarderAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, partyBIbcForwarderAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, clockAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, partyARouterAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, partyBRouterAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+			})
+
+			t.Run("tick until forwarders create ICA", func(t *testing.T) {
+				require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
+				for {
+					testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+
+					forwarderAState := testCtx.queryContractState(partyAIbcForwarderAddress)
+					forwarderBState := testCtx.queryContractState(partyBIbcForwarderAddress)
+
+					if forwarderAState == forwarderBState && forwarderBState == "ica_created" {
+						require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis), "failed to wait for blocks")
+
+						partyADepositAddress = testCtx.queryDepositAddress(partyAIbcForwarderAddress)
+						partyBDepositAddress = testCtx.queryDepositAddress(partyBIbcForwarderAddress)
+
+						println("both parties icas created: ", partyADepositAddress, " , ", partyBDepositAddress)
+						break
+					}
+				}
+			})
+
+			t.Run("fund the forwarders with sufficient funds", func(t *testing.T) {
+
+				err := cosmosOsmosis.SendFunds(ctx, sideBasedRqCaseOsmoAccount.KeyName, ibc.WalletAmount{
+					Address: partyBDepositAddress,
+					Denom:   nativeOsmoDenom,
+					Amount:  int64(osmoContributionAmount),
+				})
+				require.NoError(t, err, "failed to fund osmo forwarder")
+				err = cosmosAtom.SendFunds(ctx, sideBasedRqCaseHubAccount.KeyName, ibc.WalletAmount{
+					Address: partyADepositAddress,
+					Denom:   nativeAtomDenom,
+					Amount:  int64(atomContributionAmount),
+				})
+				require.NoError(t, err, "failed to fund gaia forwarder")
+
+				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
+				require.NoError(t, err, "failed to wait for blocks")
+
+				bal, err := cosmosAtom.GetBalance(ctx, partyADepositAddress, nativeAtomDenom)
+				require.NoError(t, err, "failed to query bal")
+				require.Equal(t, int64(atomContributionAmount), bal)
+				bal, err = cosmosOsmosis.GetBalance(ctx, partyBDepositAddress, nativeOsmoDenom)
+				require.NoError(t, err, "failed to query bal")
+				require.Equal(t, int64(osmoContributionAmount), bal)
+			})
+
+			t.Run("tick until forwarders forward the funds to holder", func(t *testing.T) {
+				for {
+					holderOsmoBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err, "failed to query holder osmo bal")
+					holderAtomBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronAtomIbcDenom)
+					require.NoError(t, err, "failed to query holder atom bal")
+
+					println("holder atom bal: ", holderAtomBal)
+					println("holder osmo bal: ", holderOsmoBal)
+
+					holderState := testCtx.queryContractState(holderAddress)
+					println("holder state: ", holderState)
+
+					if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) || holderState == "active" {
+						println("\nholder/liquidpooler received atom & osmo\n")
+						break
+					} else {
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+					}
+				}
+			})
+
+			t.Run("tick until holder sends the funds to LPer", func(t *testing.T) {
+				for {
+					liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err, "failed to query liquidPooler osmo bal")
+					liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
+					require.NoError(t, err, "failed to query liquidPooler atom bal")
+					holderLpTokenBal := queryLpTokenBalance(liquidityTokenAddress, holderAddress)
+
+					println("liquid pooler atom bal: ", liquidPoolerAtomBal)
+					println("liquid pooler osmo bal: ", liquidPoolerOsmoBal)
+					println("holder lp token balance: ", holderLpTokenBal)
+
+					if liquidPoolerOsmoBal == int64(osmoContributionAmount) && liquidPoolerAtomBal == int64(atomContributionAmount) {
+						break
+					} else {
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+					}
+				}
+			})
+
+			t.Run("tick until holder receives LP tokens", func(t *testing.T) {
+				for {
+					holderLpTokenBal := queryLpTokenBalance(liquidityTokenAddress, holderAddress)
+					println("holder lp token balance: ", holderLpTokenBal)
+					holderLpBal, err := strconv.ParseUint(holderLpTokenBal, 10, 64)
+					if err != nil {
+						panic(err)
+					}
+
+					if holderLpBal == 0 {
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+					} else {
+						break
+					}
+				}
+			})
+
+			t.Run("party A ragequits", func(t *testing.T) {
+
+				for {
+					routerAtomBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
+					require.NoError(t, err)
+
+					routerOsmoBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err)
+
+					println("routerAtomBalA: ", routerAtomBalA)
+					println("routerOsmoBalB: ", routerOsmoBalB)
+
+					if routerAtomBalA != 0 {
+						break
+					} else {
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+						testCtx.holderRagequit(holderAddress, hubNeutronAccount, keyring.BackendTest)
+					}
+				}
+			})
+
+			t.Run("tick x10", func(t *testing.T) {
+				i := 10
+				for {
+
+					if i == 0 {
+						osmoBalPartyA, err := cosmosAtom.GetBalance(
+							ctx, sideBasedRqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
+						)
+						require.NoError(t, err)
+
+						osmoBalPartyB, err := cosmosOsmosis.GetBalance(
+							ctx, sideBasedRqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+						)
+						require.NoError(t, err)
+
+						atomBalPartyA, err := cosmosAtom.GetBalance(
+							ctx, sideBasedRqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+						)
+						require.NoError(t, err)
+
+						atomBalPartyB, err := cosmosOsmosis.GetBalance(
+							ctx, sideBasedRqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+						)
+						require.NoError(t, err)
+
+						println("party A osmo bal: ", osmoBalPartyA)
+						println("party A atom bal: ", atomBalPartyA)
+						println("party B osmo bal: ", osmoBalPartyB)
+						println("party B atom bal: ", atomBalPartyB)
+						break
+					} else {
+						i = i - 1
+						testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
+					}
+				}
+			})
+
+			t.Run("tick routers until both parties receive their funds", func(t *testing.T) {
+				for {
+					osmoBalPartyB, err := cosmosOsmosis.GetBalance(
+						ctx, sideBasedRqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+					)
+					require.NoError(t, err)
+
+					atomBalPartyA, err := cosmosAtom.GetBalance(
+						ctx, sideBasedRqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+					)
+					require.NoError(t, err)
+
+					atomBalPartyB, err := cosmosOsmosis.GetBalance(
+						ctx, sideBasedRqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+					)
+					require.NoError(t, err)
+
+					println("party A atom bal: ", atomBalPartyA)
+					println("party B osmo bal: ", osmoBalPartyB)
+					println("party B atom bal: ", atomBalPartyB)
+
+					if atomBalPartyA != 0 && osmoBalPartyB != 0 && atomBalPartyB != 0 {
+						println("nice")
+						break
+					}
+
+					testCtx.tick(clockAddress, keyring.BackendTest, neutronUser.KeyName)
 				}
 			})
 		})

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -603,6 +603,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: hubReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: osmoReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -616,6 +620,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: osmoReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: hubReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -623,11 +631,8 @@ func TestTwoPartyPol(t *testing.T) {
 					},
 					FallbackSplit: nil,
 				}
-				str, err := json.Marshal(covenantMsg)
-				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
-				instantiateMsg := string(str)
 
-				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantCodeId, 10), instantiateMsg, neutronUser, keyring.BackendTest)
+				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantCodeId, 10), covenantMsg, neutronUser, keyring.BackendTest)
 
 				println("covenant address: ", covenantAddress)
 			})
@@ -944,6 +949,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: hubReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: osmoReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -957,6 +966,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: osmoReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: hubReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -964,11 +977,8 @@ func TestTwoPartyPol(t *testing.T) {
 					},
 					FallbackSplit: nil,
 				}
-				str, err := json.Marshal(covenantMsg)
-				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
-				instantiateMsg := string(str)
 
-				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantRqCodeId, 10), instantiateMsg, neutronUser, keyring.BackendTest)
+				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantRqCodeId, 10), covenantMsg, neutronUser, keyring.BackendTest)
 				println("covenant address: ", covenantAddress)
 			})
 
@@ -1279,6 +1289,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: hubReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: osmoReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -1292,6 +1306,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: osmoReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: hubReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -1299,8 +1317,8 @@ func TestTwoPartyPol(t *testing.T) {
 					},
 					FallbackSplit: nil,
 				}
-				str, _ := json.Marshal(covenantMsg)
-				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantSideBasedRqCodeId, 10), string(str), neutronUser, keyring.BackendTest)
+
+				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantSideBasedRqCodeId, 10), covenantMsg, neutronUser, keyring.BackendTest)
 				println("covenant address: ", covenantAddress)
 			})
 
@@ -1572,6 +1590,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: hubReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: osmoReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -1585,6 +1607,10 @@ func TestTwoPartyPol(t *testing.T) {
 											Address: osmoReceiverAddr,
 											Share:   "1.0",
 										},
+										{
+											Address: hubReceiverAddr,
+											Share:   "0.0",
+										},
 									},
 								},
 							},
@@ -1592,8 +1618,8 @@ func TestTwoPartyPol(t *testing.T) {
 					},
 					FallbackSplit: nil,
 				}
-				str, _ := json.Marshal(covenantMsg)
-				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantSideBasedRqCodeId, 10), string(str), neutronUser, keyring.BackendTest)
+
+				covenantAddress = testCtx.manualInstantiate(strconv.FormatUint(covenantSideBasedRqCodeId, 10), covenantMsg, neutronUser, keyring.BackendTest)
 				println("covenant address: ", covenantAddress)
 			})
 

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -838,8 +838,13 @@ func TestTwoPartyPol(t *testing.T) {
 					LiquidPoolerCode:     lperCodeId,
 				}
 
+				ragequitType := RagequitType{
+					Share: &Share{},
+				}
+
 				ragequitTerms := RagequitTerms{
-					Penalty: "0.1",
+					Penalty:      "0.1",
+					RagequitType: ragequitType,
 				}
 
 				ragequitConfig := RagequitConfig{
@@ -1476,9 +1481,12 @@ func TestTwoPartyPol(t *testing.T) {
 					HolderCode:           holderCodeId,
 					LiquidPoolerCode:     lperCodeId,
 				}
-
+				ragequitType := RagequitType{
+					Share: &Share{},
+				}
 				ragequitTerms := RagequitTerms{
-					Penalty: "0.1",
+					Penalty:      "0.1",
+					RagequitType: ragequitType,
 				}
 
 				ragequitConfig := RagequitConfig{

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -507,7 +507,7 @@ func TestTwoPartyPol(t *testing.T) {
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
 				depositBlock := Block(currentHeight + 150)
-				lockupBlock := Block(currentHeight + 200)
+				lockupBlock := Block(currentHeight + 150)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,
@@ -841,8 +841,8 @@ func TestTwoPartyPol(t *testing.T) {
 
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
-				depositBlock := Block(currentHeight + 100)
-				lockupBlock := Block(currentHeight + 200)
+				depositBlock := Block(currentHeight + 150)
+				lockupBlock := Block(currentHeight + 150)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,
@@ -1167,8 +1167,8 @@ func TestTwoPartyPol(t *testing.T) {
 
 				currentHeight, err := cosmosNeutron.Height(ctx)
 				require.NoError(t, err, "failed to get neutron height")
-				depositBlock := Block(currentHeight + 100)
-				lockupBlock := Block(currentHeight + 200)
+				depositBlock := Block(currentHeight + 150)
+				lockupBlock := Block(currentHeight + 150)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -283,6 +283,12 @@ func TestTwoPartyPol(t *testing.T) {
 	hubNeutronAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(500_000_000_000), neutron)[0]
 	osmoNeutronAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(500_000_000_000), neutron)[0]
 
+	rqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
+	rqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
+
+	// happyCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount), atom)[0]
+	// happyCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx,  "default", int64(osmoContributionAmount), osmosis)[0]
+
 	err = testutil.WaitForBlocks(ctx, 10, atom, neutron, osmosis)
 	require.NoError(t, err, "failed to wait for blocks")
 
@@ -791,24 +797,24 @@ func TestTwoPartyPol(t *testing.T) {
 		// 		}
 
 		// 		partyAConfig := CovenantPartyConfig{
-		// 			ControllerAddr:            gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix),
+		// 			ControllerAddr:            happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix),
 		// 			HostAddr:                  hubNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
 		// 			Contribution:              atomCoin,
 		// 			IbcDenom:                  neutronAtomIbcDenom,
 		// 			PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
 		// 			HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-		// 			PartyReceiverAddr:         gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix),
+		// 			PartyReceiverAddr:         happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix),
 		// 			PartyChainConnectionId:    neutronAtomIBCConnId,
 		// 			IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 		// 		}
 		// 		partyBConfig := CovenantPartyConfig{
-		// 			ControllerAddr:            osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
+		// 			ControllerAddr:            happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
 		// 			HostAddr:                  osmoNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
 		// 			Contribution:              osmoCoin,
 		// 			IbcDenom:                  neutronOsmoIbcDenom,
 		// 			PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
 		// 			HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-		// 			PartyReceiverAddr:         osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
+		// 			PartyReceiverAddr:         happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
 		// 			PartyChainConnectionId:    neutronOsmosisIBCConnId,
 		// 			IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 		// 		}
@@ -1074,16 +1080,16 @@ func TestTwoPartyPol(t *testing.T) {
 
 		// 	t.Run("fund the forwarders with sufficient funds", func(t *testing.T) {
 
-		// 		err := cosmosOsmosis.SendFunds(ctx, osmoUser.KeyName, ibc.WalletAmount{
+		// 		err := cosmosOsmosis.SendFunds(ctx, happyCaseOsmoAccount.KeyName, ibc.WalletAmount{
 		// 			Address: partyBDepositAddress,
 		// 			Denom:   nativeOsmoDenom,
-		// 			Amount:  int64(osmoContributionAmount + 1),
+		// 			Amount:  int64(osmoContributionAmount),
 		// 		})
 		// 		require.NoError(t, err, "failed to fund osmo forwarder")
-		// 		err = cosmosAtom.SendFunds(ctx, gaiaUser.KeyName, ibc.WalletAmount{
+		// 		err = cosmosAtom.SendFunds(ctx, happyCaseHubAccount.KeyName, ibc.WalletAmount{
 		// 			Address: partyADepositAddress,
 		// 			Denom:   nativeAtomDenom,
-		// 			Amount:  int64(atomContributionAmount + 1),
+		// 			Amount:  int64(atomContributionAmount),
 		// 		})
 		// 		require.NoError(t, err, "failed to fund gaia forwarder")
 
@@ -1270,22 +1276,22 @@ func TestTwoPartyPol(t *testing.T) {
 		// 	t.Run("tick routers until both parties receive their funds", func(t *testing.T) {
 		// 		for {
 		// 			osmoBalPartyA, err := cosmosAtom.GetBalance(
-		// 				ctx, gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
+		// 				ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
 		// 			)
 		// 			require.NoError(t, err)
 
 		// 			osmoBalPartyB, err := cosmosOsmosis.GetBalance(
-		// 				ctx, osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+		// 				ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
 		// 			)
 		// 			require.NoError(t, err)
 
 		// 			atomBalPartyA, err := cosmosAtom.GetBalance(
-		// 				ctx, gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+		// 				ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
 		// 			)
 		// 			require.NoError(t, err)
 
 		// 			atomBalPartyB, err := cosmosOsmosis.GetBalance(
-		// 				ctx, osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+		// 				ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
 		// 			)
 		// 			require.NoError(t, err)
 
@@ -1358,26 +1364,27 @@ func TestTwoPartyPol(t *testing.T) {
 					Denom:  cosmosOsmosis.Config().Denom,
 					Amount: strconv.FormatUint(osmoContributionAmount, 10),
 				}
-
+				hubReceiverAddr := rqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix)
+				osmoReceiverAddr := rqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix)
 				partyAConfig := CovenantPartyConfig{
-					ControllerAddr:            gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix),
+					ControllerAddr:            hubReceiverAddr,
 					HostAddr:                  hubNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
 					Contribution:              atomCoin,
 					IbcDenom:                  neutronAtomIbcDenom,
 					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-					PartyReceiverAddr:         gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix),
+					PartyReceiverAddr:         hubReceiverAddr,
 					PartyChainConnectionId:    neutronAtomIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
 				partyBConfig := CovenantPartyConfig{
-					ControllerAddr:            osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
+					ControllerAddr:            osmoReceiverAddr,
 					HostAddr:                  osmoNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
 					Contribution:              osmoCoin,
 					IbcDenom:                  neutronOsmoIbcDenom,
 					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-					PartyReceiverAddr:         osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
+					PartyReceiverAddr:         osmoReceiverAddr,
 					PartyChainConnectionId:    neutronOsmosisIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -1425,8 +1432,8 @@ func TestTwoPartyPol(t *testing.T) {
 								Custom: SplitConfig{
 									Receivers: []Receiver{
 										{
-											Address: gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix),
-											Share:   "100",
+											Address: hubReceiverAddr,
+											Share:   "1.0",
 										},
 									},
 								},
@@ -1438,8 +1445,8 @@ func TestTwoPartyPol(t *testing.T) {
 								Custom: SplitConfig{
 									Receivers: []Receiver{
 										{
-											Address: osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
-											Share:   "100",
+											Address: osmoReceiverAddr,
+											Share:   "1.0",
 										},
 									},
 								},
@@ -1672,16 +1679,16 @@ func TestTwoPartyPol(t *testing.T) {
 
 			t.Run("fund the forwarders with sufficient funds", func(t *testing.T) {
 
-				err := cosmosOsmosis.SendFunds(ctx, osmoUser.KeyName, ibc.WalletAmount{
+				err := cosmosOsmosis.SendFunds(ctx, rqCaseOsmoAccount.KeyName, ibc.WalletAmount{
 					Address: partyBDepositAddress,
 					Denom:   nativeOsmoDenom,
-					Amount:  int64(osmoContributionAmount + 1),
+					Amount:  int64(osmoContributionAmount),
 				})
 				require.NoError(t, err, "failed to fund osmo forwarder")
-				err = cosmosAtom.SendFunds(ctx, gaiaUser.KeyName, ibc.WalletAmount{
+				err = cosmosAtom.SendFunds(ctx, rqCaseHubAccount.KeyName, ibc.WalletAmount{
 					Address: partyADepositAddress,
 					Denom:   nativeAtomDenom,
-					Amount:  int64(atomContributionAmount + 1),
+					Amount:  int64(atomContributionAmount),
 				})
 				require.NoError(t, err, "failed to fund gaia forwarder")
 
@@ -1690,10 +1697,10 @@ func TestTwoPartyPol(t *testing.T) {
 
 				bal, err := cosmosAtom.GetBalance(ctx, partyADepositAddress, nativeAtomDenom)
 				require.NoError(t, err, "failed to query bal")
-				require.Equal(t, int64(atomContributionAmount+1), bal)
+				require.Equal(t, int64(atomContributionAmount), bal)
 				bal, err = cosmosOsmosis.GetBalance(ctx, partyBDepositAddress, nativeOsmoDenom)
 				require.NoError(t, err, "failed to query bal")
-				require.Equal(t, int64(osmoContributionAmount+1), bal)
+				require.Equal(t, int64(osmoContributionAmount), bal)
 			})
 
 			t.Run("tick until forwarders forward the funds to holder", func(t *testing.T) {
@@ -1805,11 +1812,11 @@ func TestTwoPartyPol(t *testing.T) {
 					routerAtomBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
 					require.NoError(t, err)
 
-					routerOsmoBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronOsmoIbcDenom)
+					routerOsmoBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronOsmoIbcDenom)
 					require.NoError(t, err)
 
 					println("routerAtomBalA: ", routerAtomBalA)
-					println("routerOsmoBalA: ", routerOsmoBalA)
+					println("routerOsmoBalB: ", routerOsmoBalB)
 
 					if routerAtomBalA != 0 {
 						break
@@ -1820,6 +1827,43 @@ func TestTwoPartyPol(t *testing.T) {
 
 						err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
 						require.NoError(t, err, "failed to wait for blocks")
+					}
+				}
+			})
+
+			t.Run("tick x10", func(t *testing.T) {
+				i := 10
+				for {
+
+					if i == 0 {
+						osmoBalPartyA, err := cosmosAtom.GetBalance(
+							ctx, rqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
+						)
+						require.NoError(t, err)
+
+						osmoBalPartyB, err := cosmosOsmosis.GetBalance(
+							ctx, rqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+						)
+						require.NoError(t, err)
+
+						atomBalPartyA, err := cosmosAtom.GetBalance(
+							ctx, rqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+						)
+						require.NoError(t, err)
+
+						atomBalPartyB, err := cosmosOsmosis.GetBalance(
+							ctx, rqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+						)
+						require.NoError(t, err)
+
+						println("party A osmo bal: ", osmoBalPartyA)
+						println("party A atom bal: ", atomBalPartyA)
+						println("party B osmo bal: ", osmoBalPartyB)
+						println("party B atom bal: ", atomBalPartyB)
+						break
+					} else {
+						i = i - 1
+						tickClock()
 					}
 				}
 			})
@@ -1868,22 +1912,22 @@ func TestTwoPartyPol(t *testing.T) {
 			t.Run("tick routers until both parties receive their funds", func(t *testing.T) {
 				for {
 					osmoBalPartyA, err := cosmosAtom.GetBalance(
-						ctx, gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
+						ctx, rqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
 					)
 					require.NoError(t, err)
 
 					osmoBalPartyB, err := cosmosOsmosis.GetBalance(
-						ctx, osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+						ctx, rqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
 					)
 					require.NoError(t, err)
 
 					atomBalPartyA, err := cosmosAtom.GetBalance(
-						ctx, gaiaUser.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+						ctx, rqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
 					)
 					require.NoError(t, err)
 
 					atomBalPartyB, err := cosmosOsmosis.GetBalance(
-						ctx, osmoUser.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+						ctx, rqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
 					)
 					require.NoError(t, err)
 
@@ -1892,7 +1936,8 @@ func TestTwoPartyPol(t *testing.T) {
 					println("party B osmo bal: ", osmoBalPartyB)
 					println("party B atom bal: ", atomBalPartyB)
 
-					if atomBalPartyA != 0 && osmoBalPartyB != 0 && atomBalPartyB != 0 {
+					if atomBalPartyA == int64(atomContributionAmount) && osmoBalPartyB == int64(osmoContributionAmount) {
+						println("nice")
 						break
 					}
 

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -286,8 +286,8 @@ func TestTwoPartyPol(t *testing.T) {
 	rqCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
 	rqCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
 
-	// happyCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount), atom)[0]
-	// happyCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx,  "default", int64(osmoContributionAmount), osmosis)[0]
+	happyCaseHubAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(atomContributionAmount+1), atom)[0]
+	happyCaseOsmoAccount := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(osmoContributionAmount+1), osmosis)[0]
 
 	err = testutil.WaitForBlocks(ctx, 10, atom, neutron, osmosis)
 	require.NoError(t, err, "failed to wait for blocks")
@@ -353,7 +353,11 @@ func TestTwoPartyPol(t *testing.T) {
 		var lperCodeId uint64
 		var covenantCodeIdStr string
 		var covenantCodeId uint64
+
+		var covenantRqCodeIdStr string
+		var covenantRqCodeId uint64
 		_ = covenantCodeId
+		_ = covenantRqCodeId
 
 		queryLpTokenBalance := func(token string, addr string) string {
 			bal := Balance{
@@ -376,6 +380,11 @@ func TestTwoPartyPol(t *testing.T) {
 			covenantCodeIdStr, err = cosmosNeutron.StoreContract(ctx, neutronUser.KeyName, covenantContractPath)
 			require.NoError(t, err, "failed to store two party pol covenant contract")
 			covenantCodeId, err = strconv.ParseUint(covenantCodeIdStr, 10, 64)
+			require.NoError(t, err, "failed to parse codeId into uint64")
+
+			covenantRqCodeIdStr, err = cosmosNeutron.StoreContract(ctx, neutronUser.KeyName, covenantContractPath)
+			require.NoError(t, err, "failed to store two party pol covenant contract")
+			covenantRqCodeId, err = strconv.ParseUint(covenantRqCodeIdStr, 10, 64)
 			require.NoError(t, err, "failed to parse codeId into uint64")
 
 			// store clock and get code id
@@ -740,576 +749,7 @@ func TestTwoPartyPol(t *testing.T) {
 			println("neutronUser lp token bal: ", neutronUserLPTokenBal)
 		})
 
-		// t.Run("two party POL happy path", func(t *testing.T) {
-
-		// 	tickClock := func() {
-		// 		println("\ntick")
-		// 		cmd := []string{"neutrond", "tx", "wasm", "execute", clockAddress,
-		// 			`{"tick":{}}`,
-		// 			"--gas-prices", "0.0untrn",
-		// 			"--gas-adjustment", `1.5`,
-		// 			"--output", "json",
-		// 			"--home", "/var/cosmos-chain/neutron-2",
-		// 			"--node", neutron.GetRPCAddress(),
-		// 			"--home", neutron.HomeDir(),
-		// 			"--chain-id", neutron.Config().ChainID,
-		// 			"--from", neutronUser.KeyName,
-		// 			"--gas", "1500000",
-		// 			"--keyring-backend", keyring.BackendTest,
-		// 			"-y",
-		// 		}
-
-		// 		resp, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
-		// 		require.NoError(t, err)
-		// 		println("tick response: ", string(resp), "\n")
-		// 		err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-		// 		require.NoError(t, err, "failed to wait for blocks")
-		// 	}
-
-		// 	t.Run("instantiate covenant", func(t *testing.T) {
-		// 		timeouts := Timeouts{
-		// 			IcaTimeout:         "100", // sec
-		// 			IbcTransferTimeout: "100", // sec
-		// 		}
-
-		// 		depositBlock := Block(500)
-		// 		lockupBlock := Block(500)
-
-		// 		lockupConfig := Expiration{
-		// 			AtHeight: &lockupBlock,
-		// 		}
-		// 		depositDeadline := Expiration{
-		// 			AtHeight: &depositBlock,
-		// 		}
-		// 		presetIbcFee := PresetIbcFee{
-		// 			AckFee:     "10000",
-		// 			TimeoutFee: "10000",
-		// 		}
-
-		// 		atomCoin := Coin{
-		// 			Denom:  cosmosAtom.Config().Denom,
-		// 			Amount: strconv.FormatUint(atomContributionAmount, 10),
-		// 		}
-
-		// 		osmoCoin := Coin{
-		// 			Denom:  cosmosOsmosis.Config().Denom,
-		// 			Amount: strconv.FormatUint(osmoContributionAmount, 10),
-		// 		}
-
-		// 		partyAConfig := CovenantPartyConfig{
-		// 			ControllerAddr:            happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix),
-		// 			HostAddr:                  hubNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
-		// 			Contribution:              atomCoin,
-		// 			IbcDenom:                  neutronAtomIbcDenom,
-		// 			PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
-		// 			HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-		// 			PartyReceiverAddr:         happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix),
-		// 			PartyChainConnectionId:    neutronAtomIBCConnId,
-		// 			IbcTransferTimeout:        timeouts.IbcTransferTimeout,
-		// 		}
-		// 		partyBConfig := CovenantPartyConfig{
-		// 			ControllerAddr:            happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
-		// 			HostAddr:                  osmoNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
-		// 			Contribution:              osmoCoin,
-		// 			IbcDenom:                  neutronOsmoIbcDenom,
-		// 			PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
-		// 			HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-		// 			PartyReceiverAddr:         happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix),
-		// 			PartyChainConnectionId:    neutronOsmosisIBCConnId,
-		// 			IbcTransferTimeout:        timeouts.IbcTransferTimeout,
-		// 		}
-		// 		codeIds := ContractCodeIds{
-		// 			IbcForwarderCode:     ibcForwarderCodeId,
-		// 			InterchainRouterCode: routerCodeId,
-		// 			ClockCode:            clockCodeId,
-		// 			HolderCode:           holderCodeId,
-		// 			LiquidPoolerCode:     lperCodeId,
-		// 		}
-
-		// 		ragequitTerms := RagequitTerms{
-		// 			Penalty: "0.1",
-		// 		}
-
-		// 		ragequitConfig := RagequitConfig{
-		// 			Enabled: &ragequitTerms,
-		// 		}
-
-		// 		poolAddress := stableswapAddress
-		// 		pairType := PairType{
-		// 			Stable: struct{}{},
-		// 		}
-
-		// 		covenantMsg := CovenantInstantiateMsg{
-		// 			Label:                    "two-party-pol-covenant",
-		// 			Timeouts:                 timeouts,
-		// 			PresetIbcFee:             presetIbcFee,
-		// 			ContractCodeIds:          codeIds,
-		// 			LockupConfig:             lockupConfig,
-		// 			PartyAConfig:             partyAConfig,
-		// 			PartyBConfig:             partyBConfig,
-		// 			PoolAddress:              poolAddress,
-		// 			RagequitConfig:           &ragequitConfig,
-		// 			DepositDeadline:          depositDeadline,
-		// 			PartyAShare:              "50",
-		// 			PartyBShare:              "50",
-		// 			ExpectedPoolRatio:        "0.1",
-		// 			AcceptablePoolRatioDelta: "0.09",
-		// 			PairType:                 pairType,
-		// 		}
-		// 		str, err := json.Marshal(covenantMsg)
-		// 		require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
-		// 		instantiateMsg := string(str)
-
-		// 		println("instantiation message: ", instantiateMsg)
-		// 		cmd := []string{"neutrond", "tx", "wasm", "instantiate", covenantCodeIdStr,
-		// 			instantiateMsg,
-		// 			"--label", "two-party-pol-covenant",
-		// 			"--no-admin",
-		// 			"--from", neutronUser.KeyName,
-		// 			"--output", "json",
-		// 			"--home", neutron.HomeDir(),
-		// 			"--node", neutron.GetRPCAddress(),
-		// 			"--chain-id", neutron.Config().ChainID,
-		// 			"--gas", "90009000",
-		// 			"--keyring-backend", keyring.BackendTest,
-		// 			"-y",
-		// 		}
-
-		// 		_, _, err = neutron.Exec(ctx, cmd, nil)
-		// 		require.NoError(t, err)
-		// 		require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis))
-
-		// 		queryCmd := []string{"neutrond", "query", "wasm",
-		// 			"list-contract-by-code", covenantCodeIdStr,
-		// 			"--output", "json",
-		// 			"--home", neutron.HomeDir(),
-		// 			"--node", neutron.GetRPCAddress(),
-		// 			"--chain-id", neutron.Config().ChainID,
-		// 		}
-
-		// 		queryResp, _, err := neutron.Exec(ctx, queryCmd, nil)
-		// 		require.NoError(t, err, "failed to query")
-
-		// 		type QueryContractResponse struct {
-		// 			Contracts  []string `json:"contracts"`
-		// 			Pagination any      `json:"pagination"`
-		// 		}
-
-		// 		contactsRes := QueryContractResponse{}
-		// 		require.NoError(t, json.Unmarshal(queryResp, &contactsRes), "failed to unmarshal contract response")
-
-		// 		covenantAddress = contactsRes.Contracts[len(contactsRes.Contracts)-1]
-
-		// 		println("covenant address: ", covenantAddress)
-		// 	})
-
-		// 	t.Run("query covenant contracts", func(t *testing.T) {
-		// 		routerQueryPartyA := InterchainRouterQuery{
-		// 			Party: Party{
-		// 				Party: "party_a",
-		// 			},
-		// 		}
-		// 		routerQueryPartyB := InterchainRouterQuery{
-		// 			Party: Party{
-		// 				Party: "party_b",
-		// 			},
-		// 		}
-		// 		forwarderQueryPartyA := IbcForwarderQuery{
-		// 			Party: Party{
-		// 				Party: "party_a",
-		// 			},
-		// 		}
-		// 		forwarderQueryPartyB := IbcForwarderQuery{
-		// 			Party: Party{
-		// 				Party: "party_b",
-		// 			},
-		// 		}
-
-		// 		var response CovenantAddressQueryResponse
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, ClockAddressQuery{}, &response)
-		// 		require.NoError(t, err, "failed to query instantiated clock address")
-		// 		clockAddress = response.Data
-		// 		println("clock addr: ", clockAddress)
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, HolderAddressQuery{}, &response)
-		// 		require.NoError(t, err, "failed to query instantiated holder address")
-		// 		holderAddress = response.Data
-		// 		println("holder addr: ", holderAddress)
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, LiquidPoolerQuery{}, &response)
-		// 		require.NoError(t, err, "failed to query instantiated liquid pooler address")
-		// 		liquidPoolerAddress = response.Data
-		// 		println("liquid pooler addr: ", liquidPoolerAddress)
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyA, &response)
-		// 		require.NoError(t, err, "failed to query instantiated party a router address")
-		// 		partyARouterAddress = response.Data
-		// 		println("partyARouterAddress: ", partyARouterAddress)
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyB, &response)
-		// 		require.NoError(t, err, "failed to query instantiated party b router address")
-		// 		partyBRouterAddress = response.Data
-		// 		println("partyBRouterAddress: ", partyBRouterAddress)
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyA, &response)
-		// 		require.NoError(t, err, "failed to query instantiated party a forwarder address")
-		// 		partyAIbcForwarderAddress = response.Data
-		// 		println("partyAIbcForwarderAddress: ", partyAIbcForwarderAddress)
-
-		// 		err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyB, &response)
-		// 		require.NoError(t, err, "failed to query instantiated party b forwarder address")
-		// 		partyBIbcForwarderAddress = response.Data
-		// 		println("partyBIbcForwarderAddress: ", partyBIbcForwarderAddress)
-		// 	})
-
-		// 	t.Run("fund contracts with neutron", func(t *testing.T) {
-		// 		err := neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: partyAIbcForwarderAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to partyAIbcForwarder contract")
-
-		// 		err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: partyBIbcForwarderAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to partyBIbcForwarder contract")
-
-		// 		err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: clockAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to clock contract")
-		// 		err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: partyARouterAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to party a router")
-		// 		err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: partyBRouterAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to party b router")
-		// 		err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: holderAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to holder")
-		// 		err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
-		// 			Address: liquidPoolerAddress,
-		// 			Amount:  5000000001,
-		// 			Denom:   nativeNtrnDenom,
-		// 		})
-		// 		require.NoError(t, err, "failed to send funds from neutron user to holder")
-
-		// 		err = testutil.WaitForBlocks(ctx, 2, atom, neutron, osmosis)
-		// 		require.NoError(t, err, "failed to wait for blocks")
-
-		// 		bal, err := neutron.GetBalance(ctx, partyAIbcForwarderAddress, nativeNtrnDenom)
-		// 		require.NoError(t, err)
-		// 		require.Equal(t, int64(5000000001), bal)
-		// 		bal, err = neutron.GetBalance(ctx, partyBIbcForwarderAddress, nativeNtrnDenom)
-		// 		require.NoError(t, err)
-		// 		require.Equal(t, int64(5000000001), bal)
-		// 		bal, err = neutron.GetBalance(ctx, clockAddress, nativeNtrnDenom)
-		// 		require.NoError(t, err)
-		// 		require.Equal(t, int64(5000000001), bal)
-		// 		bal, err = neutron.GetBalance(ctx, partyARouterAddress, nativeNtrnDenom)
-		// 		require.NoError(t, err)
-		// 		require.Equal(t, int64(5000000001), bal)
-		// 		bal, err = neutron.GetBalance(ctx, partyBRouterAddress, nativeNtrnDenom)
-		// 		require.NoError(t, err)
-		// 		require.Equal(t, int64(5000000001), bal)
-		// 	})
-
-		// 	t.Run("tick until forwarders create ICA", func(t *testing.T) {
-		// 		require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
-		// 		for {
-		// 			tickClock()
-		// 			var response CovenantAddressQueryResponse
-		// 			type ContractState struct{}
-		// 			type ContractStateQuery struct {
-		// 				ContractState ContractState `json:"contract_state"`
-		// 			}
-		// 			contractStateQuery := ContractStateQuery{
-		// 				ContractState: ContractState{},
-		// 			}
-
-		// 			require.NoError(t,
-		// 				cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, contractStateQuery, &response),
-		// 				"failed to query forwarder A state")
-		// 			forwarderAState := response.Data
-
-		// 			require.NoError(t,
-		// 				cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, contractStateQuery, &response),
-		// 				"failed to query forwarder B state")
-		// 			forwarderBState := response.Data
-
-		// 			if forwarderAState == forwarderBState && forwarderBState == "ica_created" {
-		// 				require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
-
-		// 				var depositAddressResponse CovenantAddressQueryResponse
-
-		// 				type DepositAddress struct{}
-		// 				type DepositAddressQuery struct {
-		// 					DepositAddress DepositAddress `json:"deposit_address"`
-		// 				}
-		// 				depositAddressQuery := DepositAddressQuery{
-		// 					DepositAddress: DepositAddress{},
-		// 				}
-
-		// 				err := cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
-		// 				require.NoError(t, err, "failed to query party a forwarder deposit address")
-		// 				partyADepositAddress = depositAddressResponse.Data
-
-		// 				err = cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
-		// 				require.NoError(t, err, "failed to query party b forwarder deposit address")
-		// 				partyBDepositAddress = depositAddressResponse.Data
-		// 				println("both parties icas created: ", partyADepositAddress, " , ", partyBDepositAddress)
-		// 				break
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("fund the forwarders with sufficient funds", func(t *testing.T) {
-
-		// 		err := cosmosOsmosis.SendFunds(ctx, happyCaseOsmoAccount.KeyName, ibc.WalletAmount{
-		// 			Address: partyBDepositAddress,
-		// 			Denom:   nativeOsmoDenom,
-		// 			Amount:  int64(osmoContributionAmount),
-		// 		})
-		// 		require.NoError(t, err, "failed to fund osmo forwarder")
-		// 		err = cosmosAtom.SendFunds(ctx, happyCaseHubAccount.KeyName, ibc.WalletAmount{
-		// 			Address: partyADepositAddress,
-		// 			Denom:   nativeAtomDenom,
-		// 			Amount:  int64(atomContributionAmount),
-		// 		})
-		// 		require.NoError(t, err, "failed to fund gaia forwarder")
-
-		// 		err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-		// 		require.NoError(t, err, "failed to wait for blocks")
-
-		// 		bal, err := cosmosAtom.GetBalance(ctx, partyADepositAddress, nativeAtomDenom)
-		// 		require.NoError(t, err, "failed to query bal")
-		// 		require.Equal(t, int64(atomContributionAmount+1), bal)
-		// 		bal, err = cosmosOsmosis.GetBalance(ctx, partyBDepositAddress, nativeOsmoDenom)
-		// 		require.NoError(t, err, "failed to query bal")
-		// 		require.Equal(t, int64(osmoContributionAmount+1), bal)
-		// 	})
-
-		// 	t.Run("tick until forwarders forward the funds to holder", func(t *testing.T) {
-		// 		for {
-		// 			holderOsmoBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronOsmoIbcDenom)
-		// 			require.NoError(t, err, "failed to query holder osmo bal")
-		// 			holderAtomBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronAtomIbcDenom)
-		// 			require.NoError(t, err, "failed to query holder atom bal")
-		// 			// liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
-		// 			// require.NoError(t, err, "failed to query liquidPooler osmo bal")
-		// 			// liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
-		// 			// require.NoError(t, err, "failed to query liquidPooler atom bal")
-		// 			println("holder atom bal: ", holderAtomBal)
-		// 			println("holder osmo bal: ", holderOsmoBal)
-
-		// 			var response CovenantAddressQueryResponse
-		// 			type ContractState struct{}
-		// 			type ContractStateQuery struct {
-		// 				ContractState ContractState `json:"contract_state"`
-		// 			}
-		// 			contractStateQuery := ContractStateQuery{
-		// 				ContractState: ContractState{},
-		// 			}
-
-		// 			require.NoError(t,
-		// 				cosmosNeutron.QueryContract(ctx, holderAddress, contractStateQuery, &response),
-		// 				"failed to query holder state")
-		// 			holderState := response.Data
-		// 			println("holder state: ", holderState)
-
-		// 			if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) || holderState == "active" {
-		// 				println("\nholder/liquidpooler received atom & osmo\n")
-		// 				break
-		// 			} else {
-		// 				tickClock()
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("tick until holder sends the funds to LPer", func(t *testing.T) {
-		// 		for {
-		// 			liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
-		// 			require.NoError(t, err, "failed to query liquidPooler osmo bal")
-		// 			liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
-		// 			require.NoError(t, err, "failed to query liquidPooler atom bal")
-		// 			holderLpTokenBal := queryLpTokenBalance(liquidityTokenAddress, holderAddress)
-
-		// 			println("liquid pooler atom bal: ", liquidPoolerAtomBal)
-		// 			println("liquid pooler osmo bal: ", liquidPoolerOsmoBal)
-		// 			println("holder lp token balance: ", holderLpTokenBal)
-
-		// 			if liquidPoolerOsmoBal == int64(osmoContributionAmount) && liquidPoolerAtomBal == int64(atomContributionAmount) {
-		// 				break
-		// 			} else {
-		// 				tickClock()
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("tick until holder receives LP tokens", func(t *testing.T) {
-		// 		for {
-		// 			holderLpTokenBal := queryLpTokenBalance(liquidityTokenAddress, holderAddress)
-		// 			println("holder lp token balance: ", holderLpTokenBal)
-		// 			holderLpBal, err := strconv.ParseUint(holderLpTokenBal, 10, 64)
-		// 			if err != nil {
-		// 				panic(err)
-		// 			}
-
-		// 			if holderLpBal == 0 {
-		// 				tickClock()
-		// 			} else {
-		// 				break
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("tick until holder expires", func(t *testing.T) {
-		// 		for {
-		// 			neutronHeight, err := cosmosNeutron.Height(ctx)
-		// 			require.NoError(t, err)
-
-		// 			if neutronHeight >= 515 {
-		// 				println("neutron height: ", neutronHeight)
-		// 				break
-		// 			} else {
-		// 				tickClock()
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("party A claims and router receives the funds", func(t *testing.T) {
-
-		// 		cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
-		// 			`{"claim":{}}`,
-		// 			"--from", hubNeutronAccount.GetKeyName(),
-		// 			"--gas-prices", "0.0untrn",
-		// 			"--gas-adjustment", `1.5`,
-		// 			"--output", "json",
-		// 			"--node", neutron.GetRPCAddress(),
-		// 			"--home", neutron.HomeDir(),
-		// 			"--chain-id", neutron.Config().ChainID,
-		// 			"--gas", "42069420",
-		// 			"--keyring-backend", keyring.BackendTest,
-		// 			"-y",
-		// 		}
-		// 		println("hub claim msg: ", strings.Join(cmd, " "))
-
-		// 		for {
-		// 			routerAtomBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
-		// 			require.NoError(t, err)
-
-		// 			routerOsmoBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronOsmoIbcDenom)
-		// 			require.NoError(t, err)
-
-		// 			println("routerAtomBalA: ", routerAtomBalA)
-		// 			println("routerOsmoBalA: ", routerOsmoBalA)
-
-		// 			if routerAtomBalA != 0 && routerOsmoBalA != 0 {
-		// 				break
-		// 			} else {
-		// 				tickClock()
-		// 				_, _, err = cosmosNeutron.Exec(ctx, cmd, nil)
-		// 				require.NoError(t, err, "party A claim failed")
-
-		// 				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-		// 				require.NoError(t, err, "failed to wait for blocks")
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("party B claims and router receives the funds", func(t *testing.T) {
-
-		// 		cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
-		// 			`{"claim":{}}`,
-		// 			"--from", osmoNeutronAccount.GetKeyName(),
-		// 			"--gas-prices", "0.0untrn",
-		// 			"--gas-adjustment", `1.8`,
-		// 			"--output", "json",
-		// 			"--node", neutron.GetRPCAddress(),
-		// 			"--home", neutron.HomeDir(),
-		// 			"--chain-id", neutron.Config().ChainID,
-		// 			"--gas", "42069420",
-		// 			"--keyring-backend", keyring.BackendTest,
-		// 			"-y",
-		// 		}
-
-		// 		println("osmo claim msg: ", strings.Join(cmd, " "))
-		// 		_, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
-		// 		require.NoError(t, err, "party B claim failed")
-
-		// 		err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
-		// 		require.NoError(t, err, "failed to wait for blocks")
-
-		// 		for {
-		// 			routerAtomBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronAtomIbcDenom)
-		// 			require.NoError(t, err)
-
-		// 			routerOsmoBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronOsmoIbcDenom)
-		// 			require.NoError(t, err)
-
-		// 			println("routerAtomBalB: ", routerAtomBalB)
-		// 			println("routerOsmoBalB: ", routerOsmoBalB)
-
-		// 			if routerAtomBalB != 0 || routerOsmoBalB != 0 {
-		// 				break
-		// 			} else {
-		// 				tickClock()
-		// 			}
-		// 		}
-		// 	})
-
-		// 	t.Run("tick routers until both parties receive their funds", func(t *testing.T) {
-		// 		for {
-		// 			osmoBalPartyA, err := cosmosAtom.GetBalance(
-		// 				ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
-		// 			)
-		// 			require.NoError(t, err)
-
-		// 			osmoBalPartyB, err := cosmosOsmosis.GetBalance(
-		// 				ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
-		// 			)
-		// 			require.NoError(t, err)
-
-		// 			atomBalPartyA, err := cosmosAtom.GetBalance(
-		// 				ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
-		// 			)
-		// 			require.NoError(t, err)
-
-		// 			atomBalPartyB, err := cosmosOsmosis.GetBalance(
-		// 				ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
-		// 			)
-		// 			require.NoError(t, err)
-
-		// 			println("party A osmo bal: ", osmoBalPartyA)
-		// 			println("party A atom bal: ", atomBalPartyA)
-		// 			println("party B osmo bal: ", osmoBalPartyB)
-		// 			println("party B atom bal: ", atomBalPartyB)
-
-		// 			if osmoBalPartyA != 0 && atomBalPartyA != 0 && osmoBalPartyB != 0 && atomBalPartyB != 0 {
-		// 				break
-		// 			}
-
-		// 			tickClock()
-		// 		}
-		// 	})
-		// })
-
-		t.Run("two party POL ragequit path", func(t *testing.T) {
+		t.Run("two party POL happy path", func(t *testing.T) {
 
 			tickClock := func() {
 				println("\ntick")
@@ -1342,7 +782,648 @@ func TestTwoPartyPol(t *testing.T) {
 				}
 
 				depositBlock := Block(500)
-				lockupBlock := Block(1000)
+				lockupBlock := Block(500)
+
+				lockupConfig := Expiration{
+					AtHeight: &lockupBlock,
+				}
+				depositDeadline := Expiration{
+					AtHeight: &depositBlock,
+				}
+				presetIbcFee := PresetIbcFee{
+					AckFee:     "10000",
+					TimeoutFee: "10000",
+				}
+
+				atomCoin := Coin{
+					Denom:  cosmosAtom.Config().Denom,
+					Amount: strconv.FormatUint(atomContributionAmount, 10),
+				}
+
+				osmoCoin := Coin{
+					Denom:  cosmosOsmosis.Config().Denom,
+					Amount: strconv.FormatUint(osmoContributionAmount, 10),
+				}
+
+				hubReceiverAddr := happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix)
+				osmoReceiverAddr := happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix)
+
+				partyAConfig := CovenantPartyConfig{
+					ControllerAddr:            hubReceiverAddr,
+					HostAddr:                  hubNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
+					Contribution:              atomCoin,
+					IbcDenom:                  neutronAtomIbcDenom,
+					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
+					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
+					PartyReceiverAddr:         hubReceiverAddr,
+					PartyChainConnectionId:    neutronAtomIBCConnId,
+					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
+				}
+				partyBConfig := CovenantPartyConfig{
+					ControllerAddr:            osmoReceiverAddr,
+					HostAddr:                  osmoNeutronAccount.Bech32Address(cosmosNeutron.Config().Bech32Prefix),
+					Contribution:              osmoCoin,
+					IbcDenom:                  neutronOsmoIbcDenom,
+					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
+					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
+					PartyReceiverAddr:         osmoReceiverAddr,
+					PartyChainConnectionId:    neutronOsmosisIBCConnId,
+					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
+				}
+				codeIds := ContractCodeIds{
+					IbcForwarderCode:     ibcForwarderCodeId,
+					InterchainRouterCode: routerCodeId,
+					ClockCode:            clockCodeId,
+					HolderCode:           holderCodeId,
+					LiquidPoolerCode:     lperCodeId,
+				}
+
+				ragequitTerms := RagequitTerms{
+					Penalty: "0.1",
+				}
+
+				ragequitConfig := RagequitConfig{
+					Enabled: &ragequitTerms,
+				}
+
+				poolAddress := stableswapAddress
+				pairType := PairType{
+					Stable: struct{}{},
+				}
+
+				covenantMsg := CovenantInstantiateMsg{
+					Label:                    "two-party-pol-covenant-happy",
+					Timeouts:                 timeouts,
+					PresetIbcFee:             presetIbcFee,
+					ContractCodeIds:          codeIds,
+					LockupConfig:             lockupConfig,
+					PartyAConfig:             partyAConfig,
+					PartyBConfig:             partyBConfig,
+					PoolAddress:              poolAddress,
+					RagequitConfig:           &ragequitConfig,
+					DepositDeadline:          depositDeadline,
+					PartyAShare:              "50",
+					PartyBShare:              "50",
+					ExpectedPoolRatio:        "0.1",
+					AcceptablePoolRatioDelta: "0.09",
+					PairType:                 pairType,
+					Splits: []DenomSplit{
+						{
+							Denom: neutronAtomIbcDenom,
+							Type: SplitType{
+								Custom: SplitConfig{
+									Receivers: []Receiver{
+										{
+											Address: hubReceiverAddr,
+											Share:   "1.0",
+										},
+									},
+								},
+							},
+						},
+						{
+							Denom: neutronOsmoIbcDenom,
+							Type: SplitType{
+								Custom: SplitConfig{
+									Receivers: []Receiver{
+										{
+											Address: osmoReceiverAddr,
+											Share:   "1.0",
+										},
+									},
+								},
+							},
+						},
+					},
+					FallbackSplit: nil,
+				}
+				str, err := json.Marshal(covenantMsg)
+				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
+				instantiateMsg := string(str)
+
+				println("instantiation message: ", instantiateMsg)
+				cmd := []string{"neutrond", "tx", "wasm", "instantiate", covenantCodeIdStr,
+					instantiateMsg,
+					"--label", "two-party-pol-covenant-happy",
+					"--no-admin",
+					"--from", neutronUser.KeyName,
+					"--output", "json",
+					"--home", neutron.HomeDir(),
+					"--node", neutron.GetRPCAddress(),
+					"--chain-id", neutron.Config().ChainID,
+					"--gas", "90009000",
+					"--keyring-backend", keyring.BackendTest,
+					"-y",
+				}
+
+				_, _, err = neutron.Exec(ctx, cmd, nil)
+				require.NoError(t, err)
+				require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis))
+
+				queryCmd := []string{"neutrond", "query", "wasm",
+					"list-contract-by-code", covenantCodeIdStr,
+					"--output", "json",
+					"--home", neutron.HomeDir(),
+					"--node", neutron.GetRPCAddress(),
+					"--chain-id", neutron.Config().ChainID,
+				}
+
+				queryResp, _, err := neutron.Exec(ctx, queryCmd, nil)
+				require.NoError(t, err, "failed to query")
+
+				type QueryContractResponse struct {
+					Contracts  []string `json:"contracts"`
+					Pagination any      `json:"pagination"`
+				}
+
+				contactsRes := QueryContractResponse{}
+				require.NoError(t, json.Unmarshal(queryResp, &contactsRes), "failed to unmarshal contract response")
+
+				covenantAddress = contactsRes.Contracts[len(contactsRes.Contracts)-1]
+
+				println("covenant address: ", covenantAddress)
+			})
+
+			t.Run("query covenant contracts", func(t *testing.T) {
+				routerQueryPartyA := InterchainRouterQuery{
+					Party: Party{
+						Party: "party_a",
+					},
+				}
+				routerQueryPartyB := InterchainRouterQuery{
+					Party: Party{
+						Party: "party_b",
+					},
+				}
+				forwarderQueryPartyA := IbcForwarderQuery{
+					Party: Party{
+						Party: "party_a",
+					},
+				}
+				forwarderQueryPartyB := IbcForwarderQuery{
+					Party: Party{
+						Party: "party_b",
+					},
+				}
+
+				var response CovenantAddressQueryResponse
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, ClockAddressQuery{}, &response)
+				require.NoError(t, err, "failed to query instantiated clock address")
+				clockAddress = response.Data
+				println("clock addr: ", clockAddress)
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, HolderAddressQuery{}, &response)
+				require.NoError(t, err, "failed to query instantiated holder address")
+				holderAddress = response.Data
+				println("holder addr: ", holderAddress)
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, LiquidPoolerQuery{}, &response)
+				require.NoError(t, err, "failed to query instantiated liquid pooler address")
+				liquidPoolerAddress = response.Data
+				println("liquid pooler addr: ", liquidPoolerAddress)
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyA, &response)
+				require.NoError(t, err, "failed to query instantiated party a router address")
+				partyARouterAddress = response.Data
+				println("partyARouterAddress: ", partyARouterAddress)
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, routerQueryPartyB, &response)
+				require.NoError(t, err, "failed to query instantiated party b router address")
+				partyBRouterAddress = response.Data
+				println("partyBRouterAddress: ", partyBRouterAddress)
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyA, &response)
+				require.NoError(t, err, "failed to query instantiated party a forwarder address")
+				partyAIbcForwarderAddress = response.Data
+				println("partyAIbcForwarderAddress: ", partyAIbcForwarderAddress)
+
+				err = cosmosNeutron.QueryContract(ctx, covenantAddress, forwarderQueryPartyB, &response)
+				require.NoError(t, err, "failed to query instantiated party b forwarder address")
+				partyBIbcForwarderAddress = response.Data
+				println("partyBIbcForwarderAddress: ", partyBIbcForwarderAddress)
+			})
+
+			t.Run("fund contracts with neutron", func(t *testing.T) {
+				err := neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyAIbcForwarderAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to partyAIbcForwarder contract")
+
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyBIbcForwarderAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to partyBIbcForwarder contract")
+
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: clockAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to clock contract")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyARouterAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to party a router")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: partyBRouterAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to party b router")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: holderAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to holder")
+				err = neutron.SendFunds(ctx, neutronUser.KeyName, ibc.WalletAmount{
+					Address: liquidPoolerAddress,
+					Amount:  5000000001,
+					Denom:   nativeNtrnDenom,
+				})
+				require.NoError(t, err, "failed to send funds from neutron user to holder")
+
+				err = testutil.WaitForBlocks(ctx, 2, atom, neutron, osmosis)
+				require.NoError(t, err, "failed to wait for blocks")
+
+				bal, err := neutron.GetBalance(ctx, partyAIbcForwarderAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, partyBIbcForwarderAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, clockAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, partyARouterAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+				bal, err = neutron.GetBalance(ctx, partyBRouterAddress, nativeNtrnDenom)
+				require.NoError(t, err)
+				require.Equal(t, int64(5000000001), bal)
+			})
+
+			t.Run("tick until forwarders create ICA", func(t *testing.T) {
+				require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
+				for {
+					tickClock()
+					var response CovenantAddressQueryResponse
+					type ContractState struct{}
+					type ContractStateQuery struct {
+						ContractState ContractState `json:"contract_state"`
+					}
+					contractStateQuery := ContractStateQuery{
+						ContractState: ContractState{},
+					}
+
+					require.NoError(t,
+						cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, contractStateQuery, &response),
+						"failed to query forwarder A state")
+					forwarderAState := response.Data
+
+					require.NoError(t,
+						cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, contractStateQuery, &response),
+						"failed to query forwarder B state")
+					forwarderBState := response.Data
+
+					if forwarderAState == forwarderBState && forwarderBState == "ica_created" {
+						require.NoError(t, testutil.WaitForBlocks(ctx, 15, atom, neutron, osmosis), "failed to wait for blocks")
+
+						var depositAddressResponse CovenantAddressQueryResponse
+
+						type DepositAddress struct{}
+						type DepositAddressQuery struct {
+							DepositAddress DepositAddress `json:"deposit_address"`
+						}
+						depositAddressQuery := DepositAddressQuery{
+							DepositAddress: DepositAddress{},
+						}
+
+						err := cosmosNeutron.QueryContract(ctx, partyAIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
+						require.NoError(t, err, "failed to query party a forwarder deposit address")
+						partyADepositAddress = depositAddressResponse.Data
+
+						err = cosmosNeutron.QueryContract(ctx, partyBIbcForwarderAddress, depositAddressQuery, &depositAddressResponse)
+						require.NoError(t, err, "failed to query party b forwarder deposit address")
+						partyBDepositAddress = depositAddressResponse.Data
+						println("both parties icas created: ", partyADepositAddress, " , ", partyBDepositAddress)
+						break
+					}
+				}
+			})
+
+			t.Run("fund the forwarders with sufficient funds", func(t *testing.T) {
+
+				err := cosmosOsmosis.SendFunds(ctx, happyCaseOsmoAccount.KeyName, ibc.WalletAmount{
+					Address: partyBDepositAddress,
+					Denom:   nativeOsmoDenom,
+					Amount:  int64(osmoContributionAmount),
+				})
+				require.NoError(t, err, "failed to fund osmo forwarder")
+				err = cosmosAtom.SendFunds(ctx, happyCaseHubAccount.KeyName, ibc.WalletAmount{
+					Address: partyADepositAddress,
+					Denom:   nativeAtomDenom,
+					Amount:  int64(atomContributionAmount),
+				})
+				require.NoError(t, err, "failed to fund gaia forwarder")
+
+				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
+				require.NoError(t, err, "failed to wait for blocks")
+
+				bal, err := cosmosAtom.GetBalance(ctx, partyADepositAddress, nativeAtomDenom)
+				require.NoError(t, err, "failed to query bal")
+				require.Equal(t, int64(atomContributionAmount), bal)
+				bal, err = cosmosOsmosis.GetBalance(ctx, partyBDepositAddress, nativeOsmoDenom)
+				require.NoError(t, err, "failed to query bal")
+				require.Equal(t, int64(osmoContributionAmount), bal)
+			})
+
+			t.Run("tick until forwarders forward the funds to holder", func(t *testing.T) {
+				for {
+					holderOsmoBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err, "failed to query holder osmo bal")
+					holderAtomBal, err := cosmosNeutron.GetBalance(ctx, holderAddress, neutronAtomIbcDenom)
+					require.NoError(t, err, "failed to query holder atom bal")
+					// liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
+					// require.NoError(t, err, "failed to query liquidPooler osmo bal")
+					// liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
+					// require.NoError(t, err, "failed to query liquidPooler atom bal")
+					println("holder atom bal: ", holderAtomBal)
+					println("holder osmo bal: ", holderOsmoBal)
+
+					var response CovenantAddressQueryResponse
+					type ContractState struct{}
+					type ContractStateQuery struct {
+						ContractState ContractState `json:"contract_state"`
+					}
+					contractStateQuery := ContractStateQuery{
+						ContractState: ContractState{},
+					}
+
+					require.NoError(t,
+						cosmosNeutron.QueryContract(ctx, holderAddress, contractStateQuery, &response),
+						"failed to query holder state")
+					holderState := response.Data
+					println("holder state: ", holderState)
+
+					if holderAtomBal == int64(atomContributionAmount) && holderOsmoBal == int64(osmoContributionAmount) || holderState == "active" {
+						println("\nholder/liquidpooler received atom & osmo\n")
+						break
+					} else {
+						tickClock()
+					}
+				}
+			})
+
+			t.Run("tick until holder sends the funds to LPer", func(t *testing.T) {
+				for {
+					liquidPoolerOsmoBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err, "failed to query liquidPooler osmo bal")
+					liquidPoolerAtomBal, err := cosmosNeutron.GetBalance(ctx, liquidPoolerAddress, neutronAtomIbcDenom)
+					require.NoError(t, err, "failed to query liquidPooler atom bal")
+					holderLpTokenBal := queryLpTokenBalance(liquidityTokenAddress, holderAddress)
+
+					println("liquid pooler atom bal: ", liquidPoolerAtomBal)
+					println("liquid pooler osmo bal: ", liquidPoolerOsmoBal)
+					println("holder lp token balance: ", holderLpTokenBal)
+
+					if liquidPoolerOsmoBal == int64(osmoContributionAmount) && liquidPoolerAtomBal == int64(atomContributionAmount) {
+						break
+					} else {
+						tickClock()
+					}
+				}
+			})
+
+			t.Run("tick until holder receives LP tokens", func(t *testing.T) {
+				for {
+					holderLpTokenBal := queryLpTokenBalance(liquidityTokenAddress, holderAddress)
+					println("holder lp token balance: ", holderLpTokenBal)
+					holderLpBal, err := strconv.ParseUint(holderLpTokenBal, 10, 64)
+					if err != nil {
+						panic(err)
+					}
+
+					if holderLpBal == 0 {
+						tickClock()
+					} else {
+						break
+					}
+				}
+			})
+
+			t.Run("tick until holder expires", func(t *testing.T) {
+				for {
+					neutronHeight, err := cosmosNeutron.Height(ctx)
+					require.NoError(t, err)
+
+					if neutronHeight >= 515 {
+						println("neutron height: ", neutronHeight)
+						break
+					} else {
+						tickClock()
+					}
+				}
+			})
+
+			t.Run("party A claims and router receives the funds", func(t *testing.T) {
+
+				cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
+					`{"claim":{}}`,
+					"--from", hubNeutronAccount.GetKeyName(),
+					"--gas-prices", "0.0untrn",
+					"--gas-adjustment", `1.5`,
+					"--output", "json",
+					"--node", neutron.GetRPCAddress(),
+					"--home", neutron.HomeDir(),
+					"--chain-id", neutron.Config().ChainID,
+					"--gas", "42069420",
+					"--keyring-backend", keyring.BackendTest,
+					"-y",
+				}
+				println("hub claim msg: ", strings.Join(cmd, " "))
+
+				for {
+					routerAtomBalA, err := cosmosNeutron.GetBalance(ctx, partyARouterAddress, neutronAtomIbcDenom)
+					require.NoError(t, err)
+
+					routerOsmoBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err)
+
+					println("routerAtomBalA: ", routerAtomBalA)
+					println("routerOsmoBalB: ", routerOsmoBalB)
+
+					if routerAtomBalA != 0 && routerOsmoBalB != 0 {
+						break
+					} else {
+						tickClock()
+						_, _, err = cosmosNeutron.Exec(ctx, cmd, nil)
+						require.NoError(t, err, "party A claim failed")
+
+						err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
+						require.NoError(t, err, "failed to wait for blocks")
+					}
+				}
+			})
+
+			t.Run("tick x10", func(t *testing.T) {
+				i := 10
+				for {
+
+					if i == 0 {
+						osmoBalPartyA, err := cosmosAtom.GetBalance(
+							ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
+						)
+						require.NoError(t, err)
+
+						osmoBalPartyB, err := cosmosOsmosis.GetBalance(
+							ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+						)
+						require.NoError(t, err)
+
+						atomBalPartyA, err := cosmosAtom.GetBalance(
+							ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+						)
+						require.NoError(t, err)
+
+						atomBalPartyB, err := cosmosOsmosis.GetBalance(
+							ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+						)
+						require.NoError(t, err)
+
+						println("party A osmo bal: ", osmoBalPartyA)
+						println("party A atom bal: ", atomBalPartyA)
+						println("party B osmo bal: ", osmoBalPartyB)
+						println("party B atom bal: ", atomBalPartyB)
+						break
+					} else {
+						i = i - 1
+						tickClock()
+					}
+				}
+			})
+
+			t.Run("party B claims and router receives the funds", func(t *testing.T) {
+
+				cmd := []string{"neutrond", "tx", "wasm", "execute", holderAddress,
+					`{"claim":{}}`,
+					"--from", osmoNeutronAccount.GetKeyName(),
+					"--gas-prices", "0.0untrn",
+					"--gas-adjustment", `1.8`,
+					"--output", "json",
+					"--node", neutron.GetRPCAddress(),
+					"--home", neutron.HomeDir(),
+					"--chain-id", neutron.Config().ChainID,
+					"--gas", "42069420",
+					"--keyring-backend", keyring.BackendTest,
+					"-y",
+				}
+
+				println("osmo claim msg: ", strings.Join(cmd, " "))
+				_, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
+				require.NoError(t, err, "party B claim failed")
+
+				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
+				require.NoError(t, err, "failed to wait for blocks")
+
+				for {
+					routerAtomBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronAtomIbcDenom)
+					require.NoError(t, err)
+
+					routerOsmoBalB, err := cosmosNeutron.GetBalance(ctx, partyBRouterAddress, neutronOsmoIbcDenom)
+					require.NoError(t, err)
+
+					println("routerAtomBalB: ", routerAtomBalB)
+					println("routerOsmoBalB: ", routerOsmoBalB)
+
+					if routerAtomBalB != 0 || routerOsmoBalB != 0 {
+						break
+					} else {
+						tickClock()
+					}
+				}
+			})
+
+			t.Run("tick routers until both parties receive their funds", func(t *testing.T) {
+				for {
+					osmoBalPartyA, err := cosmosAtom.GetBalance(
+						ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
+					)
+					require.NoError(t, err)
+
+					osmoBalPartyB, err := cosmosOsmosis.GetBalance(
+						ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
+					)
+					require.NoError(t, err)
+
+					atomBalPartyA, err := cosmosAtom.GetBalance(
+						ctx, happyCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), cosmosAtom.Config().Denom,
+					)
+					require.NoError(t, err)
+
+					atomBalPartyB, err := cosmosOsmosis.GetBalance(
+						ctx, happyCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), osmoNeutronAtomIbcDenom,
+					)
+					require.NoError(t, err)
+
+					println("party A osmo bal: ", osmoBalPartyA)
+					println("party A atom bal: ", atomBalPartyA)
+					println("party B osmo bal: ", osmoBalPartyB)
+					println("party B atom bal: ", atomBalPartyB)
+
+					if atomBalPartyA != 0 && osmoBalPartyB != 0 {
+						break
+					}
+
+					tickClock()
+				}
+			})
+		})
+
+		t.Run("two party POL ragequit path", func(t *testing.T) {
+
+			tickClock := func() {
+				currentHeight, _ := cosmosNeutron.Height(ctx)
+				println("\ntick @ height ", currentHeight)
+				cmd := []string{"neutrond", "tx", "wasm", "execute", clockAddress,
+					`{"tick":{}}`,
+					"--gas-prices", "0.0untrn",
+					"--gas-adjustment", `1.5`,
+					"--output", "json",
+					"--home", "/var/cosmos-chain/neutron-2",
+					"--node", neutron.GetRPCAddress(),
+					"--home", neutron.HomeDir(),
+					"--chain-id", neutron.Config().ChainID,
+					"--from", neutronUser.KeyName,
+					"--gas", "1500000",
+					"--keyring-backend", keyring.BackendTest,
+					"-y",
+				}
+
+				resp, _, err := cosmosNeutron.Exec(ctx, cmd, nil)
+				require.NoError(t, err)
+				println("tick response: ", string(resp), "\n")
+				err = testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis)
+				require.NoError(t, err, "failed to wait for blocks")
+			}
+
+			t.Run("instantiate covenant", func(t *testing.T) {
+				timeouts := Timeouts{
+					IcaTimeout:         "100", // sec
+					IbcTransferTimeout: "100", // sec
+				}
+
+				currentHeight, err := cosmosNeutron.Height(ctx)
+				require.NoError(t, err, "failed to get neutron height")
+				depositBlock := Block(currentHeight + 200)
+				lockupBlock := Block(currentHeight + 300)
 
 				lockupConfig := Expiration{
 					AtHeight: &lockupBlock,
@@ -1410,7 +1491,7 @@ func TestTwoPartyPol(t *testing.T) {
 				}
 
 				covenantMsg := CovenantInstantiateMsg{
-					Label:                    "two-party-pol-covenant",
+					Label:                    "two-party-pol-covenant-ragequit",
 					Timeouts:                 timeouts,
 					PresetIbcFee:             presetIbcFee,
 					ContractCodeIds:          codeIds,
@@ -1459,10 +1540,9 @@ func TestTwoPartyPol(t *testing.T) {
 				require.NoError(t, err, "Failed to marshall CovenantInstantiateMsg")
 				instantiateMsg := string(str)
 
-				println("instantiation message: ", instantiateMsg)
-				cmd := []string{"neutrond", "tx", "wasm", "instantiate", covenantCodeIdStr,
+				cmd := []string{"neutrond", "tx", "wasm", "instantiate", covenantRqCodeIdStr,
 					instantiateMsg,
-					"--label", "two-party-pol-covenant",
+					"--label", "two-party-pol-covenant-ragequit",
 					"--no-admin",
 					"--from", neutronUser.KeyName,
 					"--output", "json",
@@ -1474,18 +1554,21 @@ func TestTwoPartyPol(t *testing.T) {
 					"-y",
 				}
 
-				_, _, err = neutron.Exec(ctx, cmd, nil)
+				println("instantiation cmd: ", strings.Join(cmd, " "))
+
+				_, stderr, err := neutron.Exec(ctx, cmd, nil)
+				println("\ninstantiation stderr: ", string(stderr), "\n")
 				require.NoError(t, err)
 				require.NoError(t, testutil.WaitForBlocks(ctx, 5, atom, neutron, osmosis))
 
 				queryCmd := []string{"neutrond", "query", "wasm",
-					"list-contract-by-code", covenantCodeIdStr,
+					"list-contract-by-code", covenantRqCodeIdStr,
 					"--output", "json",
 					"--home", neutron.HomeDir(),
 					"--node", neutron.GetRPCAddress(),
 					"--chain-id", neutron.Config().ChainID,
 				}
-
+				println("query cmd: \n ", strings.Join(queryCmd, " "))
 				queryResp, _, err := neutron.Exec(ctx, queryCmd, nil)
 				require.NoError(t, err, "failed to query")
 
@@ -1494,10 +1577,11 @@ func TestTwoPartyPol(t *testing.T) {
 					Pagination any      `json:"pagination"`
 				}
 
-				contactsRes := QueryContractResponse{}
-				require.NoError(t, json.Unmarshal(queryResp, &contactsRes), "failed to unmarshal contract response")
+				contractsRes := QueryContractResponse{}
+				require.NoError(t, json.Unmarshal(queryResp, &contractsRes), "failed to unmarshal contract response")
 
-				covenantAddress = contactsRes.Contracts[len(contactsRes.Contracts)-1]
+				println("contracts  response: ", strings.Join(contractsRes.Contracts, " "))
+				covenantAddress = contractsRes.Contracts[len(contractsRes.Contracts)-1]
 
 				println("covenant address: ", covenantAddress)
 			})
@@ -1911,11 +1995,6 @@ func TestTwoPartyPol(t *testing.T) {
 
 			t.Run("tick routers until both parties receive their funds", func(t *testing.T) {
 				for {
-					osmoBalPartyA, err := cosmosAtom.GetBalance(
-						ctx, rqCaseHubAccount.Bech32Address(cosmosAtom.Config().Bech32Prefix), gaiaNeutronOsmoIbcDenom,
-					)
-					require.NoError(t, err)
-
 					osmoBalPartyB, err := cosmosOsmosis.GetBalance(
 						ctx, rqCaseOsmoAccount.Bech32Address(cosmosOsmosis.Config().Bech32Prefix), cosmosOsmosis.Config().Denom,
 					)
@@ -1931,12 +2010,11 @@ func TestTwoPartyPol(t *testing.T) {
 					)
 					require.NoError(t, err)
 
-					println("party A osmo bal: ", osmoBalPartyA)
 					println("party A atom bal: ", atomBalPartyA)
 					println("party B osmo bal: ", osmoBalPartyB)
 					println("party B atom bal: ", atomBalPartyB)
 
-					if atomBalPartyA == int64(atomContributionAmount) && osmoBalPartyB == int64(osmoContributionAmount) {
+					if atomBalPartyA != 0 && osmoBalPartyB != 0 && atomBalPartyB != 0 {
 						println("nice")
 						break
 					}

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -540,7 +540,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronAtomIbcDenom,
 					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-					PartyReceiverAddr:         hubReceiverAddr,
 					PartyChainConnectionId:    neutronAtomIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -551,7 +550,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronOsmoIbcDenom,
 					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-					PartyReceiverAddr:         osmoReceiverAddr,
 					PartyChainConnectionId:    neutronOsmosisIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -875,7 +873,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronAtomIbcDenom,
 					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-					PartyReceiverAddr:         hubReceiverAddr,
 					PartyChainConnectionId:    neutronAtomIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -886,7 +883,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronOsmoIbcDenom,
 					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-					PartyReceiverAddr:         osmoReceiverAddr,
 					PartyChainConnectionId:    neutronOsmosisIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -1203,7 +1199,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronAtomIbcDenom,
 					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-					PartyReceiverAddr:         hubReceiverAddr,
 					PartyChainConnectionId:    neutronAtomIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -1214,7 +1209,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronOsmoIbcDenom,
 					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-					PartyReceiverAddr:         osmoReceiverAddr,
 					PartyChainConnectionId:    neutronOsmosisIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -1492,7 +1486,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronAtomIbcDenom,
 					PartyToHostChainChannelId: testCtx.GaiaTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosAtom.Config().Name],
-					PartyReceiverAddr:         hubReceiverAddr,
 					PartyChainConnectionId:    neutronAtomIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}
@@ -1503,7 +1496,6 @@ func TestTwoPartyPol(t *testing.T) {
 					IbcDenom:                  neutronOsmoIbcDenom,
 					PartyToHostChainChannelId: testCtx.OsmoTransferChannelIds[cosmosNeutron.Config().Name],
 					HostToPartyChainChannelId: testCtx.NeutronTransferChannelIds[cosmosOsmosis.Config().Name],
-					PartyReceiverAddr:         osmoReceiverAddr,
 					PartyChainConnectionId:    neutronOsmosisIBCConnId,
 					IbcTransferTimeout:        timeouts.IbcTransferTimeout,
 				}

--- a/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
+++ b/two-party-pol-covenant/tests/interchaintest/two_party_pol_test.go
@@ -561,8 +561,7 @@ func TestTwoPartyPol(t *testing.T) {
 				}
 
 				ragequitTerms := RagequitTerms{
-					Penalty:      "0.1",
-					RagequitType: "share",
+					Penalty: "0.1",
 				}
 
 				ragequitConfig := RagequitConfig{
@@ -589,6 +588,7 @@ func TestTwoPartyPol(t *testing.T) {
 					PartyBShare:              "50",
 					ExpectedPoolRatio:        "0.1",
 					AcceptablePoolRatioDelta: "0.09",
+					CovenantType:             "share",
 					PairType:                 pairType,
 					Splits: []DenomSplit{
 						{
@@ -902,8 +902,7 @@ func TestTwoPartyPol(t *testing.T) {
 				}
 
 				ragequitTerms := RagequitTerms{
-					Penalty:      "0.1",
-					RagequitType: "share",
+					Penalty: "0.1",
 				}
 
 				ragequitConfig := RagequitConfig{
@@ -930,6 +929,7 @@ func TestTwoPartyPol(t *testing.T) {
 					PartyBShare:              "50",
 					ExpectedPoolRatio:        "0.1",
 					AcceptablePoolRatioDelta: "0.09",
+					CovenantType:             "share",
 					PairType:                 pairType,
 					Splits: []DenomSplit{
 						{
@@ -1237,8 +1237,7 @@ func TestTwoPartyPol(t *testing.T) {
 				}
 
 				ragequitTerms := RagequitTerms{
-					Penalty:      "0.1",
-					RagequitType: "side",
+					Penalty: "0.1",
 				}
 
 				ragequitConfig := RagequitConfig{
@@ -1266,6 +1265,7 @@ func TestTwoPartyPol(t *testing.T) {
 					ExpectedPoolRatio:        "0.1",
 					AcceptablePoolRatioDelta: "0.09",
 					PairType:                 pairType,
+					CovenantType:             "side",
 					Splits: []DenomSplit{
 						{
 							Denom: neutronAtomIbcDenom,

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -22,6 +22,26 @@ type CovenantInstantiateMsg struct {
 	ExpectedPoolRatio        string              `json:"expected_pool_ratio"`
 	AcceptablePoolRatioDelta string              `json:"acceptable_pool_ratio_delta"`
 	PairType                 PairType            `json:"pool_pair_type"`
+	Splits                   []DenomSplit        `json:"splits"`
+	FallbackSplit            *SplitType          `json:"fallback_split,omitempty"`
+}
+
+type SplitType struct {
+	Custom SplitConfig `json:"custom"`
+}
+
+type DenomSplit struct {
+	Denom string    `json:"denom"`
+	Type  SplitType `json:"split"`
+}
+
+type Receiver struct {
+	Address string `json:"addr"`
+	Share   string `json:"share"`
+}
+
+type SplitConfig struct {
+	Receivers []Receiver `json:"receivers"`
 }
 
 type ContractCodeIds struct {

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -76,18 +76,18 @@ type RagequitConfig struct {
 	Enabled  *RagequitTerms `json:"enabled,omitempty"`
 }
 
-type Share struct{}
-type Side struct{}
+type Share string
+type Side string
 
 type RagequitType struct {
-	Share *Share `json:"share,omitempty"`
-	Side  *Side  `json:"side,omitempty"`
+	Share string `json:"share,omitempty"`
+	Side  string `json:"side,omitempty"`
 }
 
 type RagequitTerms struct {
 	Penalty      string         `json:"penalty"`
 	State        *RagequitState `json:"state,omitempty"`
-	RagequitType RagequitType   `json:"ty"`
+	RagequitType string         `json:"ty"`
 }
 
 type RagequitState struct {

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -17,6 +17,7 @@ type CovenantInstantiateMsg struct {
 	PoolAddress              string              `json:"pool_address"`
 	RagequitConfig           *RagequitConfig     `json:"ragequit_config,omitempty"`
 	DepositDeadline          Expiration          `json:"deposit_deadline"`
+	CovenantType             string              `json:"covenant_type"`
 	PartyAShare              string              `json:"party_a_share"`
 	PartyBShare              string              `json:"party_b_share"`
 	ExpectedPoolRatio        string              `json:"expected_pool_ratio"`
@@ -79,15 +80,14 @@ type RagequitConfig struct {
 type Share string
 type Side string
 
-type RagequitType struct {
+type CovenantType struct {
 	Share string `json:"share,omitempty"`
 	Side  string `json:"side,omitempty"`
 }
 
 type RagequitTerms struct {
-	Penalty      string         `json:"penalty"`
-	State        *RagequitState `json:"state,omitempty"`
-	RagequitType string         `json:"ty"`
+	Penalty string         `json:"penalty"`
+	State   *RagequitState `json:"state,omitempty"`
 }
 
 type RagequitState struct {

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -24,7 +24,7 @@ type CovenantInstantiateMsg struct {
 	AcceptablePoolRatioDelta string              `json:"acceptable_pool_ratio_delta"`
 	PairType                 PairType            `json:"pool_pair_type"`
 	Splits                   []DenomSplit        `json:"splits"`
-	FallbackSplit            *SplitType          `json:"fallback_split,omitempty"`
+	FallbackSplit            *SplitConfig        `json:"fallback_split,omitempty"`
 }
 
 type SplitType struct {

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -109,7 +109,6 @@ type CovenantPartyConfig struct {
 	IbcDenom                  string `json:"ibc_denom"`
 	PartyToHostChainChannelId string `json:"party_to_host_chain_channel_id"`
 	HostToPartyChainChannelId string `json:"host_to_party_chain_channel_id"`
-	PartyReceiverAddr         string `json:"party_receiver_addr"`
 	PartyChainConnectionId    string `json:"party_chain_connection_id"`
 	IbcTransferTimeout        string `json:"ibc_transfer_timeout"`
 }

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -76,9 +76,18 @@ type RagequitConfig struct {
 	Enabled  *RagequitTerms `json:"enabled,omitempty"`
 }
 
+type Share struct{}
+type Side struct{}
+
+type RagequitType struct {
+	Share *Share `json:"share,omitempty"`
+	Side  *Side  `json:"side,omitempty"`
+}
+
 type RagequitTerms struct {
-	Penalty string         `json:"penalty,omitempty"`
-	State   *RagequitState `json:"state,omitempty"`
+	Penalty      string         `json:"penalty"`
+	State        *RagequitState `json:"state,omitempty"`
+	RagequitType RagequitType   `json:"ty"`
 }
 
 type RagequitState struct {

--- a/two-party-pol-covenant/tests/interchaintest/types.go
+++ b/two-party-pol-covenant/tests/interchaintest/types.go
@@ -42,7 +42,7 @@ type Receiver struct {
 }
 
 type SplitConfig struct {
-	Receivers []Receiver `json:"receivers"`
+	Receivers map[string]string `json:"receivers"`
 }
 
 type ContractCodeIds struct {


### PR DESCRIPTION
Closes #130 

- fixes interchaintest ci
- fallback split now takes `SplitConfig` instead of `SplitType`
- `CovenantType` now distinguishes between share and side based POL agreements
- removing redundant `party_receiver_addr`
- denom splits are now just `BTreeMap<String, SplitType>`, mapping denom to its split
- fallback split is now distributed separately from the explicitly defined denoms via a permisionless `DistributeFallbackSplit {}` call. thinking to add a list of denoms parameter here as it could still run out of gas.