### PR TITLE
denom filtering on interchain router

### DIFF
--- a/contracts/interchain-router/src/contract.rs
+++ b/contracts/interchain-router/src/contract.rs
@@ -69,9 +69,7 @@ pub fn execute(
             verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)?;
             try_route_balances(deps, env)
         }
-        ExecuteMsg::DistributeFallback { denoms } => {
-            try_distribute_fallback(deps, env, denoms)
-        }
+        ExecuteMsg::DistributeFallback { denoms } => try_distribute_fallback(deps, env, denoms),
     }
 }
 
@@ -188,7 +186,7 @@ pub fn migrate(
             }
 
             if let Some(denoms) = target_denoms {
-                let denoms_str = denoms.join(",").to_string();
+                let denoms_str = denoms.join(",");
                 let denom_set: BTreeSet<String> = denoms.into_iter().collect();
                 TARGET_DENOMS.save(deps.storage, &denom_set)?;
                 response = response.add_attribute("target_denoms", denoms_str);

--- a/contracts/interchain-router/src/contract.rs
+++ b/contracts/interchain-router/src/contract.rs
@@ -63,14 +63,15 @@ pub fn execute(
 ) -> NeutronResult<Response<NeutronMsg>> {
     deps.api
         .debug(format!("WASMDEBUG: execute: received msg: {msg:?}").as_str());
-
     match msg {
         ExecuteMsg::Tick {} => {
             // Verify caller is the clock
             verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)?;
             try_route_balances(deps, env)
         }
-        ExecuteMsg::DistributeFallback { denoms } => try_distribute_fallback(deps, env, denoms),
+        ExecuteMsg::DistributeFallback { denoms } => {
+            try_distribute_fallback(deps, env, denoms)
+        }
     }
 }
 

--- a/contracts/interchain-router/src/contract.rs
+++ b/contracts/interchain-router/src/contract.rs
@@ -66,7 +66,6 @@ pub fn execute(
         ExecuteMsg::Tick {} => {
             // Verify caller is the clock
             verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)?;
-
             try_route_balances(deps, env)
         }
         ExecuteMsg::DistributeFallback { denoms } => try_distribute_fallback(deps, env, denoms),
@@ -83,6 +82,8 @@ fn try_distribute_fallback(
     let explicit_denoms = DENOMS.load(deps.storage)?;
 
     for denom in denoms {
+        // we do not distribute the main covenant denoms
+        // according to the fallback split
         if explicit_denoms.contains(&denom) {
             return Err(NeutronError::Std(StdError::generic_err(
                 "unauthorized denom distribution",
@@ -157,6 +158,7 @@ pub fn query(deps: QueryDeps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             Ok(to_json_binary(&DESTINATION_CONFIG.may_load(deps.storage)?)?)
         }
         QueryMsg::ClockAddress {} => Ok(to_json_binary(&CLOCK_ADDRESS.may_load(deps.storage)?)?),
+        QueryMsg::Denoms {} => Ok(to_json_binary(&DENOMS.may_load(deps.storage)?)?),
     }
 }
 

--- a/contracts/interchain-router/src/error.rs
+++ b/contracts/interchain-router/src/error.rs
@@ -8,4 +8,7 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
+
+    #[error("unauthorized to distribute explicitly defined denom")]
+    UnauthorizedDenomDistribution {},
 }

--- a/contracts/interchain-router/src/msg.rs
+++ b/contracts/interchain-router/src/msg.rs
@@ -59,7 +59,7 @@ pub enum QueryMsg {
     #[returns(DestinationConfig)]
     DestinationConfig {},
     #[returns(BTreeSet<String>)]
-    Denoms {},
+    TargetDenoms {},
 }
 
 #[cw_serde]
@@ -67,6 +67,7 @@ pub enum MigrateMsg {
     UpdateConfig {
         clock_addr: Option<String>,
         destination_config: Option<DestinationConfig>,
+        target_denoms: Option<Vec<String>>,
     },
     UpdateCodeId {
         data: Option<Binary>,

--- a/contracts/interchain-router/src/msg.rs
+++ b/contracts/interchain-router/src/msg.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Binary, Uint64};
 use covenant_macros::{clocked, covenant_clock_address};
@@ -15,7 +17,7 @@ pub struct InstantiateMsg {
     /// timeout in seconds
     pub ibc_transfer_timeout: Uint64,
     /// specified denoms to route
-    pub denoms: Vec<String>,
+    pub denoms: BTreeSet<String>,
 }
 
 #[cw_serde]
@@ -26,18 +28,20 @@ pub struct PresetInterchainRouterFields {
     pub destination_receiver_addr: String,
     /// timeout in seconds
     pub ibc_transfer_timeout: Uint64,
+    /// specified denoms to route
+    pub denoms: BTreeSet<String>,
     pub label: String,
     pub code_id: u64,
 }
 
 impl PresetInterchainRouterFields {
-    pub fn to_instantiate_msg(&self, clock_address: String, denoms: Vec<String>) -> InstantiateMsg {
+    pub fn to_instantiate_msg(&self, clock_address: String) -> InstantiateMsg {
         InstantiateMsg {
             clock_address,
             destination_chain_channel_id: self.destination_chain_channel_id.to_string(),
             destination_receiver_addr: self.destination_receiver_addr.to_string(),
             ibc_transfer_timeout: self.ibc_transfer_timeout,
-            denoms,
+            denoms: self.denoms.clone(),
         }
     }
 }
@@ -54,6 +58,8 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(DestinationConfig)]
     DestinationConfig {},
+    #[returns(BTreeSet<String>)]
+    Denoms {},
 }
 
 #[cw_serde]

--- a/contracts/interchain-router/src/msg.rs
+++ b/contracts/interchain-router/src/msg.rs
@@ -14,6 +14,8 @@ pub struct InstantiateMsg {
     pub destination_receiver_addr: String,
     /// timeout in seconds
     pub ibc_transfer_timeout: Uint64,
+    /// specified denoms to route
+    pub denoms: Vec<String>,
 }
 
 #[cw_serde]
@@ -29,19 +31,22 @@ pub struct PresetInterchainRouterFields {
 }
 
 impl PresetInterchainRouterFields {
-    pub fn to_instantiate_msg(&self, clock_address: String) -> InstantiateMsg {
+    pub fn to_instantiate_msg(&self, clock_address: String, denoms: Vec<String>) -> InstantiateMsg {
         InstantiateMsg {
             clock_address,
             destination_chain_channel_id: self.destination_chain_channel_id.to_string(),
             destination_receiver_addr: self.destination_receiver_addr.to_string(),
             ibc_transfer_timeout: self.ibc_transfer_timeout,
+            denoms,
         }
     }
 }
 
 #[clocked]
 #[cw_serde]
-pub enum ExecuteMsg {}
+pub enum ExecuteMsg {
+    DistributeFallback { denoms: Vec<String> },
+}
 
 #[covenant_clock_address]
 #[derive(QueryResponses)]

--- a/contracts/interchain-router/src/state.rs
+++ b/contracts/interchain-router/src/state.rs
@@ -4,3 +4,4 @@ use cw_storage_plus::Item;
 
 pub const CLOCK_ADDRESS: Item<Addr> = Item::new("clock_address");
 pub const DESTINATION_CONFIG: Item<DestinationConfig> = Item::new("destination_config");
+pub const DENOMS: Item<Vec<String>> = Item::new("denoms");

--- a/contracts/interchain-router/src/state.rs
+++ b/contracts/interchain-router/src/state.rs
@@ -6,4 +6,4 @@ use cw_storage_plus::Item;
 
 pub const CLOCK_ADDRESS: Item<Addr> = Item::new("clock_address");
 pub const DESTINATION_CONFIG: Item<DestinationConfig> = Item::new("destination_config");
-pub const DENOMS: Item<BTreeSet<String>> = Item::new("denoms");
+pub const TARGET_DENOMS: Item<BTreeSet<String>> = Item::new("denoms");

--- a/contracts/interchain-router/src/state.rs
+++ b/contracts/interchain-router/src/state.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
+
 use cosmwasm_std::Addr;
 use covenant_utils::DestinationConfig;
 use cw_storage_plus::Item;
 
 pub const CLOCK_ADDRESS: Item<Addr> = Item::new("clock_address");
 pub const DESTINATION_CONFIG: Item<DestinationConfig> = Item::new("destination_config");
-pub const DENOMS: Item<Vec<String>> = Item::new("denoms");
+pub const DENOMS: Item<BTreeSet<String>> = Item::new("denoms");

--- a/contracts/interchain-router/src/suite_tests/suite.rs
+++ b/contracts/interchain-router/src/suite_tests/suite.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use cosmwasm_std::{
     testing::{MockApi, MockStorage},
@@ -55,7 +57,7 @@ impl Default for SuiteBuilder {
                 destination_chain_channel_id: DEFAULT_CHANNEL.to_string(),
                 destination_receiver_addr: DEFAULT_RECEIVER.to_string(),
                 ibc_transfer_timeout: Uint64::new(10),
-                denoms: vec![],
+                denoms: BTreeSet::new(),
             },
             app: App::default(),
         }
@@ -63,6 +65,13 @@ impl Default for SuiteBuilder {
 }
 
 impl SuiteBuilder {
+    pub fn with_denoms(mut self, denoms: Vec<String>) -> Self {
+        let covenant_denoms: BTreeSet<String> = denoms.into_iter().collect();
+
+        self.instantiate.denoms = covenant_denoms;
+        self
+    }
+
     pub fn build(self) -> Suite {
         let mut app = BasicAppBuilder::<NeutronMsg, NeutronQuery>::new_custom()
             .with_ibc(IbcAcceptingModule)
@@ -117,6 +126,13 @@ impl Suite {
         self.app
             .wrap()
             .query_wasm_smart(&self.router, &QueryMsg::DestinationConfig {})
+            .unwrap()
+    }
+
+    pub fn query_denoms(&self) -> BTreeSet<String> {
+        self.app
+            .wrap()
+            .query_wasm_smart(&self.router, &QueryMsg::Denoms {})
             .unwrap()
     }
 }

--- a/contracts/interchain-router/src/suite_tests/suite.rs
+++ b/contracts/interchain-router/src/suite_tests/suite.rs
@@ -129,10 +129,10 @@ impl Suite {
             .unwrap()
     }
 
-    pub fn query_denoms(&self) -> BTreeSet<String> {
+    pub fn query_target_denoms(&self) -> BTreeSet<String> {
         self.app
             .wrap()
-            .query_wasm_smart(&self.router, &QueryMsg::Denoms {})
+            .query_wasm_smart(&self.router, &QueryMsg::TargetDenoms {})
             .unwrap()
     }
 }

--- a/contracts/interchain-router/src/suite_tests/suite.rs
+++ b/contracts/interchain-router/src/suite_tests/suite.rs
@@ -55,6 +55,7 @@ impl Default for SuiteBuilder {
                 destination_chain_channel_id: DEFAULT_CHANNEL.to_string(),
                 destination_receiver_addr: DEFAULT_RECEIVER.to_string(),
                 ibc_transfer_timeout: Uint64::new(10),
+                denoms: vec![],
             },
             app: App::default(),
         }

--- a/contracts/interchain-router/src/suite_tests/tests.rs
+++ b/contracts/interchain-router/src/suite_tests/tests.rs
@@ -25,7 +25,7 @@ fn test_instantiate_and_query_all() {
 
     let clock = suite.query_clock_addr();
     let config = suite.query_destination_config();
-    let denoms = suite.query_denoms();
+    let denoms = suite.query_target_denoms();
 
     assert_eq!("clock", clock);
     assert_eq!(
@@ -42,7 +42,8 @@ fn test_instantiate_and_query_all() {
 #[test]
 fn test_migrate_config() {
     let mut suite = SuiteBuilder::default().build();
-
+    let target_denom_vec = vec!["new_denom_1".to_string(), "new_denom_2".to_string()];
+    let target_denom_set: BTreeSet<String> = target_denom_vec.clone().into_iter().collect();
     let migrate_msg = MigrateMsg::UpdateConfig {
         clock_addr: Some("working_clock".to_string()),
         destination_config: Some(DestinationConfig {
@@ -50,12 +51,14 @@ fn test_migrate_config() {
             destination_receiver_addr: "new_receiver".to_string(),
             ibc_transfer_timeout: Uint64::new(100),
         }),
+        target_denoms: Some(target_denom_vec),
     };
 
     suite.migrate(migrate_msg).unwrap();
 
     let clock = suite.query_clock_addr();
     let config = suite.query_destination_config();
+    let target_denoms = suite.query_target_denoms();
 
     assert_eq!("working_clock", clock);
     assert_eq!(
@@ -66,6 +69,7 @@ fn test_migrate_config() {
         },
         config
     );
+    assert_eq!(target_denom_set, target_denoms);
 }
 
 #[test]

--- a/contracts/interchain-router/src/suite_tests/tests.rs
+++ b/contracts/interchain-router/src/suite_tests/tests.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, collections::BTreeSet};
 
 use cosmwasm_std::{
     coin,
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 use covenant_utils::DestinationConfig;
 use neutron_sdk::{
     bindings::msg::{IbcFee, NeutronMsg},
-    sudo::msg::RequestPacketTimeoutHeight,
+    sudo::msg::RequestPacketTimeoutHeight, NeutronError,
 };
 
 use crate::{
@@ -25,6 +25,7 @@ fn test_instantiate_and_query_all() {
 
     let clock = suite.query_clock_addr();
     let config = suite.query_destination_config();
+    let denoms = suite.query_denoms();
 
     assert_eq!("clock", clock);
     assert_eq!(
@@ -35,6 +36,7 @@ fn test_instantiate_and_query_all() {
         },
         config
     );
+    assert_eq!(BTreeSet::new(), denoms);
 }
 
 #[test]
@@ -76,8 +78,13 @@ fn test_unauthorized_tick() {
 #[test]
 fn test_tick() {
     let usdc_coin = coin(100, "usdc");
-    let coins = vec![usdc_coin];
-    let querier: MockQuerier<Empty> = MockQuerier::new(&[("cosmos2contract", &coins)]);
+    let random_coin_1 = coin(100, "denom1");
+    let random_coin_2 = coin(100, "denom2");
+    let random_coin_3 = coin(100, "denom3");
+
+    let coins = vec![usdc_coin, random_coin_1, random_coin_2, random_coin_3];
+    let querier: MockQuerier<Empty> = MockQuerier::new(&[
+        ("cosmos2contract", &coins)]);
 
     let mut deps = OwnedDeps {
         storage: MockStorage::default(),
@@ -89,20 +96,19 @@ fn test_tick() {
     deps.querier = querier;
 
     let info = mock_info(CLOCK_ADDR, &[]);
-    let _init_msg = SuiteBuilder::default().instantiate;
 
     instantiate(
         deps.as_mut(),
         mock_env(),
-        info,
-        SuiteBuilder::default().instantiate,
+        info.clone(),
+        SuiteBuilder::default().with_denoms(vec!["usdc".to_string()]).instantiate,
     )
     .unwrap();
 
     let resp = execute(
         deps.as_mut(),
         mock_env(),
-        mock_info(CLOCK_ADDR, &[]),
+        info.clone(),
         crate::msg::ExecuteMsg::Tick {},
     )
     .unwrap();
@@ -156,4 +162,53 @@ fn test_tick() {
     // assert the expected response attributes and messages
     assert_eq!(expected_messages, resp.messages);
     assert_eq!(expected_attributes, resp.attributes);
+
+    // try to use the fallback method to distribute
+    // explicitly defined denom
+    let err = execute(
+        deps.as_mut(),
+        mock_env.clone(),
+        info.clone(),
+        crate::msg::ExecuteMsg::DistributeFallback { denoms: vec!["usdc".to_string()] },
+    )
+    .unwrap_err();
+
+    assert_eq!(err, NeutronError::Std(cosmwasm_std::StdError::generic_err("unauthorized denom distribution".to_string())));
+
+    // now distribute a valid fallback denom
+    let resp = execute(
+        deps.as_mut(),
+        mock_env,
+        info,
+        crate::msg::ExecuteMsg::DistributeFallback { denoms: vec!["denom1".to_string()] },
+    )
+    .unwrap();
+
+    for msg in resp.messages {
+        assert_eq!(
+            msg,
+            SubMsg {
+                id: 0,
+                msg: CosmosMsg::Custom(NeutronMsg::IbcTransfer {
+                    source_port: "transfer".to_string(),
+                    source_channel: "channel-1".to_string(),
+                    token: cosmwasm_std::Coin::new(100, "denom1".to_string()),
+                    sender: "cosmos2contract".to_string(),
+                    receiver: "receiver".to_string(),
+                    timeout_height: RequestPacketTimeoutHeight {
+                        revision_number: None,
+                        revision_height: None
+                    },
+                    timeout_timestamp: 1571797429879305533,
+                    memo: "hi".to_string(),
+                    fee: IbcFee {
+                        recv_fee: vec![],
+                        ack_fee: vec![cosmwasm_std::coin(1000, "untrn".to_string())],
+                        timeout_fee: vec![cosmwasm_std::coin(1000, "untrn".to_string())],
+                    } }),
+                    gas_limit: None,
+                    reply_on: cosmwasm_std::ReplyOn::Never,
+            }
+        );
+    }
 }

--- a/contracts/interchain-router/src/suite_tests/tests.rs
+++ b/contracts/interchain-router/src/suite_tests/tests.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, collections::BTreeSet};
+use std::{collections::BTreeSet, marker::PhantomData};
 
 use cosmwasm_std::{
     coin,
@@ -8,7 +8,8 @@ use cosmwasm_std::{
 use covenant_utils::DestinationConfig;
 use neutron_sdk::{
     bindings::msg::{IbcFee, NeutronMsg},
-    sudo::msg::RequestPacketTimeoutHeight, NeutronError,
+    sudo::msg::RequestPacketTimeoutHeight,
+    NeutronError,
 };
 
 use crate::{
@@ -87,8 +88,7 @@ fn test_tick() {
     let random_coin_3 = coin(100, "denom3");
 
     let coins = vec![usdc_coin, random_coin_1, random_coin_2, random_coin_3];
-    let querier: MockQuerier<Empty> = MockQuerier::new(&[
-        ("cosmos2contract", &coins)]);
+    let querier: MockQuerier<Empty> = MockQuerier::new(&[("cosmos2contract", &coins)]);
 
     let mut deps = OwnedDeps {
         storage: MockStorage::default(),
@@ -105,7 +105,9 @@ fn test_tick() {
         deps.as_mut(),
         mock_env(),
         info.clone(),
-        SuiteBuilder::default().with_denoms(vec!["usdc".to_string()]).instantiate,
+        SuiteBuilder::default()
+            .with_denoms(vec!["usdc".to_string()])
+            .instantiate,
     )
     .unwrap();
 
@@ -173,18 +175,27 @@ fn test_tick() {
         deps.as_mut(),
         mock_env.clone(),
         info.clone(),
-        crate::msg::ExecuteMsg::DistributeFallback { denoms: vec!["usdc".to_string()] },
+        crate::msg::ExecuteMsg::DistributeFallback {
+            denoms: vec!["usdc".to_string()],
+        },
     )
     .unwrap_err();
 
-    assert_eq!(err, NeutronError::Std(cosmwasm_std::StdError::generic_err("unauthorized denom distribution".to_string())));
+    assert_eq!(
+        err,
+        NeutronError::Std(cosmwasm_std::StdError::generic_err(
+            "unauthorized denom distribution".to_string()
+        ))
+    );
 
     // now distribute a valid fallback denom
     let resp = execute(
         deps.as_mut(),
         mock_env,
         info,
-        crate::msg::ExecuteMsg::DistributeFallback { denoms: vec!["denom1".to_string()] },
+        crate::msg::ExecuteMsg::DistributeFallback {
+            denoms: vec!["denom1".to_string()],
+        },
     )
     .unwrap();
 
@@ -209,9 +220,10 @@ fn test_tick() {
                         recv_fee: vec![],
                         ack_fee: vec![cosmwasm_std::coin(1000, "untrn".to_string())],
                         timeout_fee: vec![cosmwasm_std::coin(1000, "untrn".to_string())],
-                    } }),
-                    gas_limit: None,
-                    reply_on: cosmwasm_std::ReplyOn::Never,
+                    }
+                }),
+                gas_limit: None,
+                reply_on: cosmwasm_std::ReplyOn::Never,
             }
         );
     }

--- a/contracts/swap-covenant/src/contract.rs
+++ b/contracts/swap-covenant/src/contract.rs
@@ -72,7 +72,11 @@ pub fn instantiate(
         ibc_fee: msg.preset_ibc_fee.to_ibc_fee(),
     };
 
-    let covenant_denoms: BTreeSet<String> = msg.splits.iter().map(|split| split.denom.to_string()).collect();
+    let covenant_denoms: BTreeSet<String> = msg
+        .splits
+        .iter()
+        .map(|split| split.denom.to_string())
+        .collect();
 
     let preset_party_a_router_fields = PresetInterchainRouterFields {
         destination_chain_channel_id: msg.party_a_config.host_to_party_chain_channel_id,

--- a/contracts/swap-covenant/src/contract.rs
+++ b/contracts/swap-covenant/src/contract.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -69,12 +71,16 @@ pub fn instantiate(
         ibc_transfer_timeout: msg.timeouts.ibc_transfer_timeout,
         ibc_fee: msg.preset_ibc_fee.to_ibc_fee(),
     };
+
+    let covenant_denoms: BTreeSet<String> = msg.splits.iter().map(|split| split.denom.to_string()).collect();
+
     let preset_party_a_router_fields = PresetInterchainRouterFields {
         destination_chain_channel_id: msg.party_a_config.host_to_party_chain_channel_id,
         destination_receiver_addr: msg.party_a_config.party_receiver_addr,
         ibc_transfer_timeout: msg.party_a_config.ibc_transfer_timeout,
         label: format!("{}_party_a_interchain_router", msg.label),
         code_id: msg.contract_codes.interchain_router_code,
+        denoms: covenant_denoms.clone(),
     };
     let preset_party_b_router_fields = PresetInterchainRouterFields {
         destination_chain_channel_id: msg.party_b_config.host_to_party_chain_channel_id,
@@ -82,6 +88,7 @@ pub fn instantiate(
         ibc_transfer_timeout: msg.party_b_config.ibc_transfer_timeout,
         label: format!("{}_party_b_interchain_router", msg.label),
         code_id: msg.contract_codes.interchain_router_code,
+        denoms: covenant_denoms,
     };
     let preset_splitter_fields = PresetInterchainSplitterFields {
         splits: msg.splits,

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -50,7 +50,11 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    let covenant_denoms: BTreeSet<String> = msg.splits.iter().map(|split| split.denom.to_string()).collect();
+    let covenant_denoms: BTreeSet<String> = msg
+        .splits
+        .iter()
+        .map(|split| split.denom.to_string())
+        .collect();
 
     let preset_clock_fields = PresetClockFields {
         tick_max_gas: msg.clock_tick_max_gas,

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -48,6 +50,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    let covenant_denoms: BTreeSet<String> = msg.splits.iter().map(|split| split.denom.to_string()).collect();
 
     let preset_clock_fields = PresetClockFields {
         tick_max_gas: msg.clock_tick_max_gas,
@@ -113,6 +116,7 @@ pub fn instantiate(
         ibc_transfer_timeout: msg.party_a_config.ibc_transfer_timeout,
         label: format!("{}_party_a_interchain_router", msg.label),
         code_id: msg.contract_codes.router_code,
+        denoms: covenant_denoms.clone(),
     };
     let preset_party_b_router_fields = PresetInterchainRouterFields {
         destination_chain_channel_id: msg.party_b_config.host_to_party_chain_channel_id,
@@ -120,6 +124,7 @@ pub fn instantiate(
         ibc_transfer_timeout: msg.party_b_config.ibc_transfer_timeout,
         label: format!("{}_party_b_interchain_router", msg.label),
         code_id: msg.contract_codes.router_code,
+        denoms: covenant_denoms,
     };
 
     let preset_liquid_pooler_fields = PresetAstroLiquidPoolerFields {

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -422,6 +422,10 @@ pub enum ExecuteMsg {
     Claim {},
     /// distribute any unspecified denoms
     DistributeFallbackSplit { denoms: Vec<String> },
+    // / pulls out all the liquidity without rq penalty.
+    // / the funds are then distributed in the expected
+    // / manner.
+    // EmergencyShutdown {},
 }
 
 #[cw_serde]

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -525,7 +525,7 @@ impl DestinationConfig {
         address: String,
     ) -> Vec<CosmosMsg<NeutronMsg>> {
         let mut messages: Vec<CosmosMsg<NeutronMsg>> = vec![];
-
+        // TODO: what if neutron wants to tokenswap?
         for coin in coins {
             if coin.denom != "untrn" {
                 messages.push(CosmosMsg::Custom(NeutronMsg::IbcTransfer {

--- a/packages/covenant-utils/src/lib.rs
+++ b/packages/covenant-utils/src/lib.rs
@@ -517,6 +517,29 @@ pub struct DestinationConfig {
     pub ibc_transfer_timeout: Uint64,
 }
 
+pub fn default_ibc_ack_fee_amount() -> Uint128 {
+    Uint128::new(1000)
+}
+
+pub fn default_ibc_timeout_fee_amount() -> Uint128 {
+    Uint128::new(1000)
+}
+
+pub fn default_ibc_fee() -> IbcFee {
+    IbcFee {
+        // must be empty
+        recv_fee: vec![],
+        ack_fee: vec![cosmwasm_std::Coin {
+            denom: "untrn".to_string(),
+            amount: default_ibc_ack_fee_amount(),
+        }],
+        timeout_fee: vec![cosmwasm_std::Coin {
+            denom: "untrn".to_string(),
+            amount: default_ibc_timeout_fee_amount(),
+        }],
+    }
+}
+
 impl DestinationConfig {
     pub fn get_ibc_transfer_messages_for_coins(
         &self,
@@ -542,18 +565,7 @@ impl DestinationConfig {
                         .plus_seconds(self.ibc_transfer_timeout.u64())
                         .nanos(),
                     memo: "hi".to_string(),
-                    fee: IbcFee {
-                        // must be empty
-                        recv_fee: vec![],
-                        ack_fee: vec![cosmwasm_std::Coin {
-                            denom: "untrn".to_string(),
-                            amount: Uint128::new(1000),
-                        }],
-                        timeout_fee: vec![cosmwasm_std::Coin {
-                            denom: "untrn".to_string(),
-                            amount: Uint128::new(1000),
-                        }],
-                    },
+                    fee: default_ibc_fee(),
                 }));
             }
         }


### PR DESCRIPTION
closes #132 

- introduces a `DistributeFallback` message that distributes non target denoms
- normal balance routing only takes target denoms into account