### PR TITLE
liquid staker fsm cleanup

### DIFF
--- a/contracts/stride-liquid-staker/src/contract.rs
+++ b/contracts/stride-liquid-staker/src/contract.rs
@@ -80,7 +80,7 @@ pub fn execute(
     match (CONTRACT_STATE.load(deps.storage)?, msg) {
         // tick in Instantiated state tries to register an ICA
         (ContractState::Instantiated, ExecuteMsg::Tick {}) => {
-            try_register_stride_ica(deps, info, env)
+            try_register_stride_ica(deps, env, info)
         }
         // tick in IcaCreated state is a no-op
         (ContractState::IcaCreated, ExecuteMsg::Tick {}) => {
@@ -111,8 +111,8 @@ pub fn execute(
 /// registers an interchain account on stride with port_id associated with `INTERCHAIN_ACCOUNT_ID`
 fn try_register_stride_ica(
     deps: ExecuteDeps,
-    info: MessageInfo,
     env: Env,
+    info: MessageInfo,
 ) -> NeutronResult<Response<NeutronMsg>> {
     verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)?;
     let remote_chain_info = REMOTE_CHAIN_INFO.load(deps.storage)?;

--- a/contracts/stride-liquid-staker/src/error.rs
+++ b/contracts/stride-liquid-staker/src/error.rs
@@ -1,1 +1,32 @@
+use cosmwasm_std::StdError;
+use neutron_sdk::NeutronError;
+use thiserror::Error;
 
+use crate::msg::{ContractState, ExecuteMsg};
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("State machine error: cannot perform {0:?} from {1:?} state")]
+    StateMachineError(ExecuteMsg, ContractState),
+
+    #[error("Next contract is not ready for receiving the funds yet")]
+    NextContractError {},
+
+    #[error("Unsupported reply id: {0}")]
+    UnsupportedReplyIdError(u64),
+}
+
+impl From<ContractError> for NeutronError {
+    fn from(value: ContractError) -> Self {
+        NeutronError::Std(StdError::generic_err(value.to_string()))
+    }
+}
+
+impl From<ContractError> for StdError {
+    fn from(value: ContractError) -> Self {
+        StdError::generic_err(value.to_string())
+    }
+}

--- a/unit-tests/src/test_single_party_covenant/test.rs
+++ b/unit-tests/src/test_single_party_covenant/test.rs
@@ -1,6 +1,6 @@
-use cosmwasm_std::{coin, to_json_binary, Addr, Event, StdError, Uint128, Uint64};
+use cosmwasm_std::{coin, to_json_binary, Addr, Event, Uint128, Uint64};
 use covenant_utils::{neutron::RemoteChainInfo, op_mode::ContractOperationModeConfig};
-use cw_multi_test::{AppResponse, Executor};
+use cw_multi_test::Executor;
 
 use crate::setup::{
     base_suite::BaseSuiteMut, ADMIN, DENOM_ATOM, DENOM_ATOM_ON_NTRN, DENOM_LS_ATOM_ON_NTRN,

--- a/unit-tests/src/test_single_party_covenant/test.rs
+++ b/unit-tests/src/test_single_party_covenant/test.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{coin, to_json_binary, Addr, Event, Uint128, Uint64};
+use cosmwasm_std::{coin, to_json_binary, Addr, Event, StdError, Uint128, Uint64};
 use covenant_utils::{neutron::RemoteChainInfo, op_mode::ContractOperationModeConfig};
 use cw_multi_test::{AppResponse, Executor};
 
@@ -12,7 +12,7 @@ use super::suite::Suite;
 #[test]
 fn test_covenant() {
     let mut suite = Suite::new_with_stable_pool();
-    let resp: AppResponse = suite
+    suite
         .app
         .execute_contract(
             suite.admin.clone(),
@@ -22,13 +22,7 @@ fn test_covenant() {
             },
             &[],
         )
-        .unwrap();
-
-    resp.assert_event(
-        &Event::new("wasm")
-            .add_attribute("method", "try_permisionless_transfer")
-            .add_attribute("ica_status", "not_created"),
-    );
+        .unwrap_err();
 
     suite.get_and_fund_depositors(coin(1_000_000_000_000_u128, DENOM_ATOM));
 

--- a/unit-tests/src/test_single_party_covenant/test.rs
+++ b/unit-tests/src/test_single_party_covenant/test.rs
@@ -1,6 +1,7 @@
-use cosmwasm_std::{coin, to_json_binary, Addr, Event, Uint128, Uint64};
+use cosmwasm_std::{coin, to_json_binary, Addr, Event, StdError, Uint128, Uint64};
 use covenant_utils::{neutron::RemoteChainInfo, op_mode::ContractOperationModeConfig};
 use cw_multi_test::Executor;
+use neutron_sdk::NeutronError;
 
 use crate::setup::{
     base_suite::BaseSuiteMut, ADMIN, DENOM_ATOM, DENOM_ATOM_ON_NTRN, DENOM_LS_ATOM_ON_NTRN,
@@ -12,7 +13,7 @@ use super::suite::Suite;
 #[test]
 fn test_covenant() {
     let mut suite = Suite::new_with_stable_pool();
-    suite
+    let err: NeutronError = suite
         .app
         .execute_contract(
             suite.admin.clone(),
@@ -22,7 +23,15 @@ fn test_covenant() {
             },
             &[],
         )
-        .unwrap_err();
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        NeutronError::Std(StdError::generic_err(
+            "State machine error: cannot perform Transfer { amount: Uint128(500000000000) } from Instantiated state",
+        )),
+    );
 
     suite.get_and_fund_depositors(coin(1_000_000_000_000_u128, DENOM_ATOM));
 


### PR DESCRIPTION
closes #278 

also adds non-std errors for the contract.

curious what are the thoughts on something like this:

```rust
    #[error("State machine error: cannot perform {0:?} from {1:?} state")]
    StateMachineError(ExecuteMsg, ContractState),
```

which would be used in a way similar to this:

```rust
match (CONTRACT_STATE.load(deps.storage)?, msg) {
        < ... >
        // in order to perform the transfer, ICA needs to be created
        (ContractState::Instantiated, ExecuteMsg::Transfer { amount }) => {
            Err(ContractError::StateMachineError(
                ExecuteMsg::Transfer { amount },
                ContractState::Instantiated,
            )
            .into())
        }
    }
```

I think it may be nice to generalize this state machine error type for all FSM-based contracts. We could have a dedicated fsm error trait for imposing a specific format that would return error messages along the lines of "cannot perform <domain specific action> from <domain specific contract state>". Thoughts?