### PR TITLE
swap holder FSM cleanup

### DIFF
--- a/contracts/swap-holder/src/contract.rs
+++ b/contracts/swap-holder/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    to_json_binary, Addr, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, StdResult, Uint128,
+    ensure, to_json_binary, Addr, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    Response, StdError, StdResult, Uint128,
 };
 use covenant_utils::{
     clock::{enqueue_msg, verify_clock},
@@ -34,11 +34,11 @@ pub fn instantiate(
     let next_contract = deps.api.addr_validate(&msg.next_contract)?;
     let clock_addr = deps.api.addr_validate(&msg.clock_address)?;
     msg.parties_config.validate_party_addresses(deps.api)?;
-    if msg.lockup_config.is_expired(&env.block) {
-        return Err(ContractError::Std(StdError::generic_err(
-            "past lockup config",
-        )));
-    }
+    ensure!(
+        !msg.lockup_config.is_expired(&env.block),
+        StdError::generic_err("past lockup config")
+    );
+
     deps.api
         .addr_validate(&msg.refund_config.party_a_refund_address)?;
     deps.api
@@ -65,21 +65,16 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    match msg {
-        ExecuteMsg::Tick {} => try_tick(deps, env, info),
-    }
-}
-
-/// attempts to advance the state machine. performs `info.sender` validation
-fn try_tick(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
     // Verify caller is the clock
     verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)?;
 
-    let current_state = CONTRACT_STATE.load(deps.storage)?;
-    match current_state {
-        ContractState::Instantiated => try_forward(deps, env, info.sender),
-        ContractState::Expired => try_refund(deps, env),
-        ContractState::Complete => Ok(Response::default()
+    match (CONTRACT_STATE.load(deps.storage)?, msg) {
+        // from instantiated state we attempt to forward the funds
+        (ContractState::Instantiated, ExecuteMsg::Tick {}) => try_forward(deps, env, info.sender),
+        // from expired state we attempt to refund any available funds
+        (ContractState::Expired, ExecuteMsg::Tick {}) => try_refund(deps, env),
+        // completed state is terminal, noop
+        (ContractState::Complete, ExecuteMsg::Tick {}) => Ok(Response::default()
             .add_attribute("contract_state", "complete")
             .add_attribute("method", "try_tick")),
     }
@@ -90,16 +85,15 @@ fn try_tick(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Cont
 fn try_refund(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     let parties = PARTIES_CONFIG.load(deps.storage)?;
     let refund_config = REFUND_CONFIG.load(deps.storage)?;
+    let contract_addr = env.contract.address;
 
     // query holder balances
-    let party_a_bal = deps.querier.query_balance(
-        env.contract.address.to_string(),
-        parties.party_a.native_denom,
-    )?;
-    let party_b_bal = deps.querier.query_balance(
-        env.contract.address.to_string(),
-        parties.party_b.native_denom,
-    )?;
+    let party_a_bal = deps
+        .querier
+        .query_balance(&contract_addr, parties.party_a.native_denom)?;
+    let party_b_bal = deps
+        .querier
+        .query_balance(&contract_addr, parties.party_b.native_denom)?;
 
     let refund_messages: Vec<CosmosMsg> =
         match (party_a_bal.amount.is_zero(), party_b_bal.amount.is_zero()) {
@@ -137,6 +131,8 @@ fn try_refund(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
 
 fn try_forward(mut deps: DepsMut, env: Env, clock_addr: Addr) -> Result<Response, ContractError> {
     let lockup_config = LOCKUP_CONFIG.load(deps.storage)?;
+    let contract_addr = env.contract.address;
+
     // check if covenant is expired
     if lockup_config.is_expired(&env.block) {
         CONTRACT_STATE.save(deps.storage, &ContractState::Expired)?;
@@ -151,10 +147,10 @@ fn try_forward(mut deps: DepsMut, env: Env, clock_addr: Addr) -> Result<Response
 
     let mut party_a_coin = deps
         .querier
-        .query_balance(env.contract.address.clone(), parties.party_a.native_denom)?;
+        .query_balance(&contract_addr, parties.party_a.native_denom)?;
     let mut party_b_coin = deps
         .querier
-        .query_balance(env.contract.address, parties.party_b.native_denom)?;
+        .query_balance(&contract_addr, parties.party_b.native_denom)?;
 
     if party_a_coin.amount < covenant_terms.party_a_amount {
         party_a_coin.amount = Uint128::zero();
@@ -180,9 +176,9 @@ fn try_forward(mut deps: DepsMut, env: Env, clock_addr: Addr) -> Result<Response
 
     // if query returns None, then we error and wait
     let Some(deposit_address) = deposit_address_query else {
-        return Err(ContractError::Std(StdError::not_found(
-            "Next contract is not ready for receiving the funds yet",
-        )));
+        return Err(
+            StdError::not_found("Next contract is not ready for receiving the funds yet").into(),
+        );
     };
 
     let bank_msg = BankMsg::Send {

--- a/contracts/swap-holder/src/error.rs
+++ b/contracts/swap-holder/src/error.rs
@@ -21,4 +21,7 @@ pub enum ContractError {
 
     #[error("unexpected reply id")]
     UnexpectedReplyId {},
+
+    #[error("Lockup config must be in the future")]
+    LockupConfigValidationError {},
 }

--- a/unit-tests/src/test_swap_holder/tests.rs
+++ b/unit-tests/src/test_swap_holder/tests.rs
@@ -28,7 +28,7 @@ fn test_instantiate_validates_clock_address() {
 }
 
 #[test]
-#[should_panic(expected = "past lockup config")]
+#[should_panic(expected = "Lockup config must be in the future")]
 fn test_instantiate_validates_lockup_config() {
     SwapHolderBuilder::default()
         .with_lockup_config(Expiration::AtHeight(0))


### PR DESCRIPTION
closes #279

merges the `try_tick` method into the main execute handler.
also adds `ContractError::LockupConfigValidationError` variant that replaces a generic std error from before.