### PR TITLE
osmo liquid pooler fsm cleanup

### DIFF
--- a/contracts/osmo-liquid-pooler/src/contract.rs
+++ b/contracts/osmo-liquid-pooler/src/contract.rs
@@ -175,7 +175,7 @@ fn try_initiate_withdrawal(
 ) -> NeutronResult<Response<NeutronMsg>> {
     ensure!(
         info.sender == HOLDER_ADDRESS.load(deps.storage)?,
-        ContractError::NotHolder {}.to_neutron_std()
+        ContractError::NotHolder {}
     );
 
     let withdraw_share = percentage.unwrap_or(Decimal::one());
@@ -186,7 +186,6 @@ fn try_initiate_withdrawal(
             "withdraw percentage must be in range (0, 1], got {:?}",
             withdraw_share
         ),))
-        .to_neutron_std()
     );
 
     // we advance the contract state to `PendingWithdrawal` and force latest balances sync
@@ -284,7 +283,7 @@ pub fn try_withdraw(
     let lp_redeem_amount = lp_bal
         .amount
         .checked_multiply_ratio(withdraw_share.numerator(), withdraw_share.denominator())
-        .map_err(|e| ContractError::CheckedMultiplyError(e).to_neutron_std())?;
+        .map_err(ContractError::CheckedMultiplyError)?;
 
     let exit_pool_message: CosmosMsg = WasmMsg::Execute {
         contract_addr: lp_config.outpost.to_string(),

--- a/contracts/osmo-liquid-pooler/src/contract.rs
+++ b/contracts/osmo-liquid-pooler/src/contract.rs
@@ -118,10 +118,52 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> NeutronResult<Response<NeutronMsg>> {
-    match msg {
-        ExecuteMsg::Tick {} => try_tick(deps, env, info),
-        ExecuteMsg::Callback(callback_msg) => try_handle_callback(env, deps, info, callback_msg),
-        ExecuteMsg::Withdraw { percentage } => try_initiate_withdrawal(deps, info, percentage),
+    match (CONTRACT_STATE.load(deps.storage)?, msg) {
+        // ticks to instantiated state try to create the proxy
+        (ContractState::Instantiated, ExecuteMsg::Tick {}) => try_create_proxy(deps, env, info),
+        // ticks to proxy_created state try to fund the proxy account
+        (ContractState::ProxyCreated, ExecuteMsg::Tick {}) => try_deliver_funds(deps, env, info),
+        // ticks to proxy_funded state try to provide liquidity
+        (ContractState::ProxyFunded { funding_expiration }, ExecuteMsg::Tick {}) => {
+            // the funding expiration is due, we advance the state to
+            // Active. it will enable withdrawals and start pulling
+            // any non-LP tokens from proxy back to this contract.
+            verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+            if funding_expiration.is_expired(&env.block) {
+                CONTRACT_STATE.save(deps.storage, &ContractState::Active)?;
+                Ok(Response::default()
+                    .add_attribute("method", "tick")
+                    .add_attribute("contract_state", "active"))
+            } else {
+                // otherwise we attempt to provide liquidity
+                try_provide_liquidity(deps, env, info)
+            }
+        }
+        // ticks to active state try to sync the proxy balances
+        (ContractState::Active, ExecuteMsg::Tick {}) => try_sync_proxy_balances(deps, env, info),
+        // ticks to pending_withdrawal state try to withdraw the LP tokens
+        (ContractState::PendingWithdrawal { share }, ExecuteMsg::Tick {}) => {
+            let lp_config = LIQUIDITY_PROVISIONING_CONFIG.load(deps.storage)?;
+            match lp_config.get_proxy_balances() {
+                Some((party_1_bal, party_2_bal, lp_bal)) => try_withdraw(
+                    deps,
+                    env,
+                    info,
+                    share,
+                    (party_1_bal, party_2_bal, lp_bal),
+                    lp_config.clone(),
+                ),
+                None => try_sync_proxy_balances(deps, env, info),
+            }
+        }
+        // ticks to distributing state try to distribute the withdrawn coins
+        (ContractState::Distributing { coins }, ExecuteMsg::Tick {}) => {
+            try_distribute(deps, env, info, coins)
+        }
+        (_, ExecuteMsg::Callback(callback_msg)) => {
+            try_handle_callback(env, deps, info, callback_msg)
+        }
+        (_, ExecuteMsg::Withdraw { percentage }) => try_initiate_withdrawal(deps, info, percentage),
     }
 }
 
@@ -223,10 +265,13 @@ fn withdraw_party_denoms(
 pub fn try_withdraw(
     deps: ExecuteDeps,
     env: Env,
+    info: MessageInfo,
     withdraw_share: Decimal,
     (party_1_bal, party_2_bal, lp_bal): (&Coin, &Coin, &Coin),
     lp_config: LiquidityProvisionConfig,
 ) -> NeutronResult<Response<NeutronMsg>> {
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+
     let note_address = NOTE_ADDRESS.load(deps.storage)?;
     let ibc_config = IBC_CONFIG.load(deps.storage)?;
 
@@ -282,53 +327,14 @@ pub fn try_withdraw(
     Ok(Response::default().add_messages(vec![exit_pool_note_msg]))
 }
 
-/// attempts to advance the state machine. performs `info.sender` validation.
-fn try_tick(deps: ExecuteDeps, env: Env, info: MessageInfo) -> NeutronResult<Response<NeutronMsg>> {
-    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
-
-    match CONTRACT_STATE.load(deps.storage)? {
-        // create a proxy account
-        ContractState::Instantiated => try_create_proxy(deps, env),
-        // fund the proxy account
-        ContractState::ProxyCreated => try_deliver_funds(deps, env),
-        // attempt to provide liquidity
-        ContractState::ProxyFunded { funding_expiration } => {
-            // the funding expiration is due, we advance the state to
-            // Active. it will enable withdrawals and start pulling
-            // any non-LP tokens from proxy back to this contract.
-            if funding_expiration.is_expired(&env.block) {
-                CONTRACT_STATE.save(deps.storage, &ContractState::Active)?;
-                Ok(Response::default()
-                    .add_attribute("method", "tick")
-                    .add_attribute("contract_state", "active"))
-            } else {
-                // otherwise we attempt to provide liquidity
-                try_provide_liquidity(deps, env)
-            }
-        }
-        ContractState::Active => try_sync_proxy_balances(deps, env),
-        ContractState::PendingWithdrawal { share } => {
-            let lp_config = LIQUIDITY_PROVISIONING_CONFIG.load(deps.storage)?;
-            match lp_config.get_proxy_balances() {
-                Some((party_1_bal, party_2_bal, lp_bal)) => try_withdraw(
-                    deps,
-                    env,
-                    share,
-                    (party_1_bal, party_2_bal, lp_bal),
-                    lp_config.clone(),
-                ),
-                None => try_sync_proxy_balances(deps, env),
-            }
-        }
-        ContractState::Distributing { coins } => try_distribute(deps, env, coins),
-    }
-}
-
 fn try_distribute(
     deps: ExecuteDeps,
     env: Env,
+    info: MessageInfo,
     coins: Vec<Coin>,
 ) -> NeutronResult<Response<NeutronMsg>> {
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+
     let mut lp_config = LIQUIDITY_PROVISIONING_CONFIG.load(deps.storage)?;
     // query our own relevant token denoms
     let denom_1_balance = deps.querier.query_balance(
@@ -511,7 +517,13 @@ fn try_distribute(
     }
 }
 
-fn try_sync_proxy_balances(deps: ExecuteDeps, env: Env) -> NeutronResult<Response<NeutronMsg>> {
+fn try_sync_proxy_balances(
+    deps: ExecuteDeps,
+    env: Env,
+    info: MessageInfo,
+) -> NeutronResult<Response<NeutronMsg>> {
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+
     let note_address = NOTE_ADDRESS.load(deps.storage)?;
     let ibc_config = IBC_CONFIG.load(deps.storage)?;
     let mut lp_config = LIQUIDITY_PROVISIONING_CONFIG.load(deps.storage)?;
@@ -541,7 +553,13 @@ fn try_sync_proxy_balances(deps: ExecuteDeps, env: Env) -> NeutronResult<Respons
 /// state to `proxy_created`.
 /// see polytone_handlers `process_execute_callback` match statement
 /// handling the CREATE_PROXY_CALLBACK_ID for details.
-fn try_create_proxy(deps: ExecuteDeps, env: Env) -> NeutronResult<Response<NeutronMsg>> {
+fn try_create_proxy(
+    deps: ExecuteDeps,
+    env: Env,
+    info: MessageInfo,
+) -> NeutronResult<Response<NeutronMsg>> {
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+
     let note_address = NOTE_ADDRESS.load(deps.storage)?;
     let ibc_config = IBC_CONFIG.load(deps.storage)?;
 
@@ -565,7 +583,13 @@ fn try_create_proxy(deps: ExecuteDeps, env: Env) -> NeutronResult<Response<Neutr
         .add_attribute("method", "try_create_proxy"))
 }
 
-fn try_deliver_funds(deps: ExecuteDeps, env: Env) -> NeutronResult<Response<NeutronMsg>> {
+fn try_deliver_funds(
+    deps: ExecuteDeps,
+    env: Env,
+    info: MessageInfo,
+) -> NeutronResult<Response<NeutronMsg>> {
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+
     let mut lp_config = LIQUIDITY_PROVISIONING_CONFIG.load(deps.storage)?;
 
     // check if both balances have a recent query
@@ -660,7 +684,13 @@ fn try_fund_proxy(deps: ExecuteDeps, env: Env) -> NeutronResult<Response<Neutron
         .add_attribute("method", "try_fund_proxy"))
 }
 
-fn try_provide_liquidity(deps: ExecuteDeps, env: Env) -> NeutronResult<Response<NeutronMsg>> {
+fn try_provide_liquidity(
+    deps: ExecuteDeps,
+    env: Env,
+    info: MessageInfo,
+) -> NeutronResult<Response<NeutronMsg>> {
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
+
     let note_address = NOTE_ADDRESS.load(deps.storage)?;
     let ibc_config = IBC_CONFIG.load(deps.storage)?;
     let mut lp_config = LIQUIDITY_PROVISIONING_CONFIG.load(deps.storage)?;

--- a/contracts/osmo-liquid-pooler/src/error.rs
+++ b/contracts/osmo-liquid-pooler/src/error.rs
@@ -38,14 +38,8 @@ pub enum ContractError {
     NotHolder {},
 }
 
-impl ContractError {
-    pub fn to_std(&self) -> StdError {
-        StdError::GenericErr {
-            msg: self.to_string(),
-        }
-    }
-
-    pub fn to_neutron_std(&self) -> NeutronError {
-        NeutronError::Std(self.to_std())
+impl From<ContractError> for NeutronError {
+    fn from(value: ContractError) -> Self {
+        NeutronError::Std(StdError::generic_err(value.to_string()))
     }
 }

--- a/contracts/osmo-liquid-pooler/src/error.rs
+++ b/contracts/osmo-liquid-pooler/src/error.rs
@@ -36,6 +36,9 @@ pub enum ContractError {
 
     #[error("Only holder can withdraw the position")]
     NotHolder {},
+
+    #[error("Withdraw percentage must be in range (0, 1], got {0}")]
+    InvalidWithdrawPercentage(String),
 }
 
 impl From<ContractError> for NeutronError {

--- a/contracts/osmo-liquid-pooler/src/polytone_handlers.rs
+++ b/contracts/osmo-liquid-pooler/src/polytone_handlers.rs
@@ -47,7 +47,7 @@ pub fn try_handle_callback(
     // only the note can submit a callback
     ensure!(
         info.sender == NOTE_ADDRESS.load(deps.storage)?,
-        ContractError::Unauthorized {}.to_neutron_std()
+        ContractError::Unauthorized {}
     );
 
     match msg.result {
@@ -76,7 +76,7 @@ fn process_query_callback(
             "unexpected callback id: {:?}",
             initiator_msg
         ))
-        .to_neutron_std()),
+        .into()),
     }
 }
 
@@ -89,7 +89,7 @@ fn process_execute_callback(
     let initiator_msg: u8 = from_json(initiator_msg)?;
     let callback_result: ExecutionResponse = match execute_callback_result {
         Ok(val) => val,
-        Err(e) => return Err(ContractError::PolytoneError(e).to_neutron_std()),
+        Err(e) => return Err(ContractError::PolytoneError(e).into()),
     };
 
     match initiator_msg {
@@ -262,7 +262,7 @@ fn handle_proxy_balances_callback(
             }
             val
         }
-        Err(err) => return Err(ContractError::PolytoneError(err.error).to_neutron_std()),
+        Err(err) => return Err(ContractError::PolytoneError(err.error).into()),
     };
 
     // store the latest prices in lp config

--- a/contracts/osmo-liquid-pooler/src/polytone_handlers.rs
+++ b/contracts/osmo-liquid-pooler/src/polytone_handlers.rs
@@ -302,13 +302,13 @@ pub fn get_note_execute_neutron_msg(
 
 pub fn get_ibc_withdraw_coin_message(
     channel_id: String,
-    to_address: String,
+    to_address: &str,
     amount: Coin,
     timeout: IbcTimeout,
 ) -> CosmosMsg {
     let msg = IbcMsg::Transfer {
         channel_id,
-        to_address,
+        to_address: to_address.to_string(),
         amount,
         timeout,
     };


### PR DESCRIPTION
closes #280 

also:
- introduces `InvalidWithdrawPercentage` error type (instead of returning `StdError`) and cleans up error handling
- addresses some small nits