### PR TITLE
two party holder op mode

### DIFF
--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -96,13 +96,12 @@ pub fn instantiate(
         msg.contract_codes.liquid_pooler_code,
     )?;
 
-    let mut clock_whitelist: Vec<String> = Vec::with_capacity(6);
-    clock_whitelist.push(holder_instantiate2_config.addr.to_string());
-
-    let mut clock_initial_queue = vec![];
-    clock_initial_queue.push(liquid_pooler_instantiate2_config.addr.to_string());
-    clock_initial_queue.push(party_a_router_instantiate2_config.addr.to_string());
-    clock_initial_queue.push(party_b_router_instantiate2_config.addr.to_string());
+    let mut clock_initial_queue = vec![
+        liquid_pooler_instantiate2_config.addr.to_string(),
+        party_a_router_instantiate2_config.addr.to_string(),
+        party_b_router_instantiate2_config.addr.to_string(),
+        holder_instantiate2_config.addr.to_string(),
+    ];
 
     let holder_instantiate2_msg = valence_two_party_pol_holder::msg::InstantiateMsg {
         op_mode_cfg: op_mode_cfg.clone(),
@@ -247,18 +246,20 @@ pub fn instantiate(
         );
     }
 
-    let clock_instantiate2_msg = valence_clock::msg::InstantiateMsg {
-        tick_max_gas: msg.clock_tick_max_gas,
-        whitelist: clock_whitelist,
-        initial_queue: clock_initial_queue,
-    }
-    .to_instantiate2_msg(
-        clock_instantiate2_config.code,
-        clock_instantiate2_config.salt,
-        env.contract.address.to_string(),
-        format!("{}-clock", msg.label),
-    )?;
-    messages.insert(0, clock_instantiate2_msg);
+    messages.insert(
+        0,
+        valence_clock::msg::InstantiateMsg {
+            tick_max_gas: msg.clock_tick_max_gas,
+            whitelist: vec![],
+            initial_queue: clock_initial_queue,
+        }
+        .to_instantiate2_msg(
+            clock_instantiate2_config.code,
+            clock_instantiate2_config.salt,
+            env.contract.address.to_string(),
+            format!("{}-clock", msg.label),
+        )?,
+    );
 
     CONTRACT_CODES.save(
         deps.storage,

--- a/contracts/two-party-pol-covenant/src/contract.rs
+++ b/contracts/two-party-pol-covenant/src/contract.rs
@@ -105,7 +105,7 @@ pub fn instantiate(
     clock_initial_queue.push(party_b_router_instantiate2_config.addr.to_string());
 
     let holder_instantiate2_msg = valence_two_party_pol_holder::msg::InstantiateMsg {
-        clock_address: clock_instantiate2_config.addr.to_string(),
+        op_mode_cfg: op_mode_cfg.clone(),
         lockup_config: msg.lockup_config,
         next_contract: liquid_pooler_instantiate2_config.addr.to_string(),
         ragequit_config: msg.ragequit_config.unwrap_or(RagequitConfig::Disabled),

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -3,19 +3,19 @@ use std::collections::BTreeMap;
 
 use cosmwasm_std::{
     ensure, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, Response, StdError, StdResult,
+    MessageInfo, Reply, Response, StdError, StdResult, SubMsg,
 };
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
-use covenant_utils::clock::{enqueue_msg, verify_clock};
+use covenant_utils::op_mode::{verify_caller, ContractOperationMode};
 use covenant_utils::split::SplitConfig;
 use covenant_utils::withdraw_lp_helper::{generate_withdraw_msg, EMERGENCY_COMMITTEE_ADDR};
 use cw2::set_contract_version;
 
 use crate::msg::CovenantType;
-use crate::state::{WithdrawState, LIQUID_POOLER_ADDRESS, WITHDRAW_STATE};
+use crate::state::{WithdrawState, CONTRACT_OP_MODE, LIQUID_POOLER_ADDRESS, WITHDRAW_STATE};
 use crate::{
     error::ContractError,
     msg::{
@@ -23,8 +23,8 @@ use crate::{
         RagequitConfig, RagequitState, TwoPartyPolCovenantConfig, TwoPartyPolCovenantParty,
     },
     state::{
-        CLOCK_ADDRESS, CONTRACT_STATE, COVENANT_CONFIG, DENOM_SPLITS, DEPOSIT_DEADLINE,
-        LOCKUP_CONFIG, RAGEQUIT_CONFIG,
+        CONTRACT_STATE, COVENANT_CONFIG, DENOM_SPLITS, DEPOSIT_DEADLINE, LOCKUP_CONFIG,
+        RAGEQUIT_CONFIG,
     },
 };
 
@@ -41,7 +41,7 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let next_contract = deps.api.addr_validate(&msg.next_contract)?;
-    let clock_addr = deps.api.addr_validate(&msg.clock_address)?;
+    let op_mode = ContractOperationMode::try_init(deps.api, msg.op_mode_cfg.clone())?;
 
     // ensure that the deposit deadline is in the future
     ensure!(
@@ -103,7 +103,7 @@ pub fn instantiate(
         },
     )?;
     LIQUID_POOLER_ADDRESS.save(deps.storage, &next_contract)?;
-    CLOCK_ADDRESS.save(deps.storage, &clock_addr)?;
+    CONTRACT_OP_MODE.save(deps.storage, &op_mode)?;
     LOCKUP_CONFIG.save(deps.storage, &msg.lockup_config)?;
     RAGEQUIT_CONFIG.save(deps.storage, &msg.ragequit_config)?;
     CONTRACT_STATE.save(deps.storage, &ContractState::Instantiated)?;
@@ -111,7 +111,6 @@ pub fn instantiate(
     DEPOSIT_DEADLINE.save(deps.storage, &msg.deposit_deadline)?;
 
     Ok(Response::default()
-        .add_message(enqueue_msg(clock_addr.as_str())?)
         .add_attribute("method", "two_party_pol_holder_instantiate")
         .add_attributes(msg.get_response_attributes()))
 }
@@ -195,13 +194,12 @@ fn try_claim(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError
 
     // if both parties already claimed everything we complete early
     if claim_party.allocation.is_zero() && counterparty.allocation.is_zero() {
-        let clock_address = CLOCK_ADDRESS.load(deps.storage)?;
-        let dequeue_message = ContractState::complete_and_dequeue(deps, clock_address.as_str())?;
+        let dequeue_messages = ContractState::complete_and_get_dequeue_msgs(deps)?;
 
         return Ok(Response::default()
             .add_attribute("method", "try_claim")
             .add_attribute("contract_state", "complete")
-            .add_message(dequeue_message));
+            .add_submessages(dequeue_messages));
     }
 
     // set WithdrawState to include original data
@@ -341,8 +339,9 @@ fn try_claim_share_based(
     mut covenant_config: TwoPartyPolCovenantConfig,
     denom_splits: DenomSplits,
 ) -> Result<Response, ContractError> {
-    let mut messages = denom_splits
+    let messages = denom_splits
         .get_single_receiver_distribution_messages(funds, claim_party.router.to_string());
+    let mut submsgs: Vec<SubMsg> = vec![];
 
     claim_party.allocation = Decimal::zero();
 
@@ -350,11 +349,9 @@ fn try_claim_share_based(
     if !counterparty.allocation.is_zero() {
         counterparty.allocation = Decimal::one();
     } else {
-        // otherwise both parties claimed everything and we can complete
-        let clock_address = CLOCK_ADDRESS.load(deps.storage)?;
-        let dequeue_message =
-            ContractState::complete_and_dequeue(deps.branch(), clock_address.as_str())?;
-        messages.push(dequeue_message.into());
+        println!("attempting to dequeue and complete");
+        let dequeue_msgs = ContractState::complete_and_get_dequeue_msgs(deps.branch())?;
+        submsgs.extend(dequeue_msgs);
     };
 
     covenant_config.update_parties(claim_party, counterparty);
@@ -363,7 +360,8 @@ fn try_claim_share_based(
 
     Ok(Response::default()
         .add_attribute("method", "claim_share_based")
-        .add_messages(messages))
+        .add_messages(messages)
+        .add_submessages(submsgs))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -383,21 +381,20 @@ fn try_claim_side_based(
 
     // update the states and dequeue from the clock
     COVENANT_CONFIG.save(deps.storage, &covenant_config)?;
-    let clock_address = CLOCK_ADDRESS.load(deps.storage)?;
-    let dequeue_message = ContractState::complete_and_dequeue(deps, clock_address.as_str())?;
+    // let clock_address = CLOCK_ADDRESS.load(deps.storage)?;
+    let dequeue_messages = ContractState::complete_and_get_dequeue_msgs(deps)?;
 
     Ok(Response::default()
         .add_attribute("method", "claim_side_based")
         .add_messages(messages)
-        .add_message(dequeue_message))
+        .add_submessages(dequeue_messages))
 }
 
 /// attempts to route any available covenant party contribution denoms to
 /// the parties that were responsible for contributing that denom.
 fn try_refund(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
     // Verify caller is the clock
-    verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)
-        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
 
     let config = COVENANT_CONFIG.load(deps.storage)?;
     let contract_addr = env.contract.address.to_string();
@@ -435,8 +432,7 @@ fn try_refund(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Co
 
 fn try_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
     // Verify caller is the clock
-    verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)
-        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
 
     let deposit_deadline = DEPOSIT_DEADLINE.load(deps.storage)?;
     if deposit_deadline.is_expired(&env.block) {
@@ -482,8 +478,7 @@ fn try_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, C
 
 fn check_expiration(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
     // Verify caller is the clock
-    verify_clock(&info.sender, &CLOCK_ADDRESS.load(deps.storage)?)
-        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
 
     let lockup_config = LOCKUP_CONFIG.load(deps.storage)?;
 
@@ -593,7 +588,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::ContractState {} => Ok(to_json_binary(&CONTRACT_STATE.load(deps.storage)?)?),
         QueryMsg::RagequitConfig {} => Ok(to_json_binary(&RAGEQUIT_CONFIG.load(deps.storage)?)?),
         QueryMsg::LockupConfig {} => Ok(to_json_binary(&LOCKUP_CONFIG.load(deps.storage)?)?),
-        QueryMsg::ClockAddress {} => Ok(to_json_binary(&CLOCK_ADDRESS.load(deps.storage)?)?),
+        QueryMsg::OperationMode {} => Ok(to_json_binary(&CONTRACT_OP_MODE.load(deps.storage)?)?),
         QueryMsg::NextContract {} => {
             Ok(to_json_binary(&LIQUID_POOLER_ADDRESS.load(deps.storage)?)?)
         }
@@ -617,7 +612,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
     match msg {
         MigrateMsg::UpdateConfig {
-            clock_addr,
+            op_mode,
             next_contract,
             lockup_config,
             deposit_deadline,
@@ -629,10 +624,12 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
         } => {
             let mut resp = Response::default().add_attribute("method", "update_config");
 
-            if let Some(addr) = clock_addr {
-                let clock_address = deps.api.addr_validate(&addr)?;
-                CLOCK_ADDRESS.save(deps.storage, &clock_address)?;
-                resp = resp.add_attribute("clock_addr", addr);
+            if let Some(op_mode_cfg) = op_mode {
+                let updated_op_mode = ContractOperationMode::try_init(deps.api, op_mode_cfg)
+                    .map_err(|err| StdError::generic_err(err.to_string()))?;
+
+                CONTRACT_OP_MODE.save(deps.storage, &updated_op_mode)?;
+                resp = resp.add_attribute("op_mode", format!("{:?}", updated_op_mode));
             }
 
             if let Some(addr) = next_contract {
@@ -701,5 +698,16 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
             // let data: SomeStruct = from_binary(&data)?;
             Ok(Response::default())
         }
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    // if we get a reply with id u64::MAX, we can assume it is a dequeue message
+    if msg.id == u64::MAX {
+        // Do nothing, whether it fails or not (dequeue messages are "fire & forget" style messages)
+        Ok(Response::default())
+    } else {
+        Err(ContractError::UnexpectedReplyId {})
     }
 }

--- a/contracts/two-party-pol-holder/src/contract.rs
+++ b/contracts/two-party-pol-holder/src/contract.rs
@@ -349,7 +349,6 @@ fn try_claim_share_based(
     if !counterparty.allocation.is_zero() {
         counterparty.allocation = Decimal::one();
     } else {
-        println!("attempting to dequeue and complete");
         let dequeue_msgs = ContractState::complete_and_get_dequeue_msgs(deps.branch())?;
         submsgs.extend(dequeue_msgs);
     };
@@ -379,9 +378,8 @@ fn try_claim_side_based(
     counterparty.allocation = Decimal::zero();
     covenant_config.update_parties(claim_party, counterparty);
 
-    // update the states and dequeue from the clock
+    // update the states and dequeue from any clocks
     COVENANT_CONFIG.save(deps.storage, &covenant_config)?;
-    // let clock_address = CLOCK_ADDRESS.load(deps.storage)?;
     let dequeue_messages = ContractState::complete_and_get_dequeue_msgs(deps)?;
 
     Ok(Response::default()
@@ -393,7 +391,7 @@ fn try_claim_side_based(
 /// attempts to route any available covenant party contribution denoms to
 /// the parties that were responsible for contributing that denom.
 fn try_refund(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
-    // Verify caller is the clock
+    // Verify caller is an authorized address
     verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
 
     let config = COVENANT_CONFIG.load(deps.storage)?;
@@ -431,7 +429,7 @@ fn try_refund(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Co
 }
 
 fn try_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
-    // Verify caller is the clock
+    // Verify caller is an authorized address
     verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
 
     let deposit_deadline = DEPOSIT_DEADLINE.load(deps.storage)?;
@@ -477,7 +475,7 @@ fn try_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, C
 }
 
 fn check_expiration(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
-    // Verify caller is the clock
+    // Verify caller is an authorized address
     verify_caller(&info.sender, &CONTRACT_OP_MODE.load(deps.storage)?)?;
 
     let lockup_config = LOCKUP_CONFIG.load(deps.storage)?;

--- a/contracts/two-party-pol-holder/src/error.rs
+++ b/contracts/two-party-pol-holder/src/error.rs
@@ -1,10 +1,14 @@
 use cosmwasm_std::StdError;
+use covenant_utils::op_mode::ContractOperationError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
+
+    #[error(transparent)]
+    ContractOperationError(#[from] ContractOperationError),
 
     #[error("party allocations must add up to 1.0")]
     AllocationValidationError {},
@@ -23,6 +27,9 @@ pub enum ContractError {
 
     #[error("covenant is not in active state")]
     NotActive {},
+
+    #[error("unexpected reply id")]
+    UnexpectedReplyId {},
 
     #[error("covenant is active but expired; tick to proceed")]
     Expired {},

--- a/contracts/two-party-pol-holder/src/msg.rs
+++ b/contracts/two-party-pol-holder/src/msg.rs
@@ -424,7 +424,8 @@ impl ContractState {
                 let mut dequeue_msgs: Vec<SubMsg> = vec![];
                 for addr in privileged_addrs.to_vec() {
                     if deps.querier.query_wasm_contract_info(addr.as_str()).is_ok() {
-                        let dequeue_submsg = SubMsg::reply_on_error(dequeue_msg(addr.as_str())?, u64::MAX);
+                        let dequeue_submsg =
+                            SubMsg::reply_on_error(dequeue_msg(addr.as_str())?, u64::MAX);
                         dequeue_msgs.push(dequeue_submsg);
                     }
                 }

--- a/contracts/two-party-pol-holder/src/state.rs
+++ b/contracts/two-party-pol-holder/src/state.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
+use covenant_utils::op_mode::ContractOperationMode;
 use cw_storage_plus::Item;
 use cw_utils::Expiration;
 
@@ -9,8 +10,7 @@ use crate::msg::{
 
 pub const CONTRACT_STATE: Item<ContractState> = Item::new("contract_state");
 
-/// authorized clock contract
-pub const CLOCK_ADDRESS: Item<Addr> = Item::new("clock_address");
+pub const CONTRACT_OP_MODE: Item<ContractOperationMode> = Item::new("contract_op_mode");
 
 /// address of the liquidity pool to which we provide liquidity
 pub const LIQUID_POOLER_ADDRESS: Item<Addr> = Item::new("pooler_address");

--- a/unit-tests/src/setup/contracts.rs
+++ b/unit-tests/src/setup/contracts.rs
@@ -536,7 +536,17 @@ pub fn two_party_holder_contract() -> Box<dyn Contract<NeutronMsg, NeutronQuery>
         ))
     };
 
-    let contract = ContractWrapper::new(exec, init, query).with_migrate(migrate);
+    let reply = |deps: DepsMut<NeutronQuery>, env: Env, reply: Reply| {
+        execute_into_neutron(valence_two_party_pol_holder::contract::reply(
+            get_empty_depsmut(deps),
+            env,
+            reply,
+        ))
+    };
+
+    let contract = ContractWrapper::new(exec, init, query)
+        .with_migrate(migrate)
+        .with_reply(reply);
     Box::new(contract)
 }
 

--- a/unit-tests/src/setup/instantiates/two_party_pol_holder.rs
+++ b/unit-tests/src/setup/instantiates/two_party_pol_holder.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, str::FromStr};
 
 use cosmwasm_std::{coin, Addr, Decimal};
-use covenant_utils::split::SplitConfig;
+use covenant_utils::{op_mode::ContractOperationModeConfig, split::SplitConfig};
 use cw_utils::Expiration;
 
 use crate::setup::{DENOM_ATOM_ON_NTRN, DENOM_LS_ATOM_ON_NTRN};
@@ -20,7 +20,7 @@ impl From<TwoPartyHolderInstantiate> for valence_two_party_pol_holder::msg::Inst
 impl TwoPartyHolderInstantiate {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        clock_address: String,
+        op_mode_cfg: ContractOperationModeConfig,
         next_contract: String,
         lockup_config: Expiration,
         ragequit_config: valence_two_party_pol_holder::msg::RagequitConfig,
@@ -32,7 +32,7 @@ impl TwoPartyHolderInstantiate {
     ) -> Self {
         Self {
             msg: valence_two_party_pol_holder::msg::InstantiateMsg {
-                clock_address,
+                op_mode_cfg,
                 next_contract,
                 lockup_config,
                 ragequit_config,
@@ -46,8 +46,8 @@ impl TwoPartyHolderInstantiate {
     }
 
     /* Change functions */
-    pub fn with_clock(&mut self, addr: &str) -> &mut Self {
-        self.msg.clock_address = addr.to_string();
+    pub fn with_op_mode(&mut self, op_mode: &ContractOperationModeConfig) -> &mut Self {
+        self.msg.op_mode_cfg = op_mode.clone();
         self
     }
 
@@ -100,7 +100,7 @@ impl TwoPartyHolderInstantiate {
 
 impl TwoPartyHolderInstantiate {
     pub fn default(
-        clock_address: String,
+        op_mode_cfg: ContractOperationModeConfig,
         next_contract: String,
         party_a_addr: Addr,
         party_b_addr: Addr,
@@ -116,7 +116,7 @@ impl TwoPartyHolderInstantiate {
 
         Self {
             msg: valence_two_party_pol_holder::msg::InstantiateMsg {
-                clock_address,
+                op_mode_cfg,
                 next_contract,
                 lockup_config: Expiration::AtHeight(200000),
                 ragequit_config: valence_two_party_pol_holder::msg::RagequitConfig::Disabled {},


### PR DESCRIPTION
closes #252 

currently the e2e tests are failing because the existing go interchaintests had not had their types adjusted to the new tick mode. considering that issues like #231 , #232 , and #233 are already in progress, I suggest not doing double work and adjusting the e2e tests in this pr. this is because once the migration to local-interchain is complete, we will unlock the ability to reuse our rust types directly without the need to convert them to go types.
