### PR TITLE
Add Local-Ic Relayer Edge Case Tests for Remote Chain Splitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
  "valence-ibc-forwarder",
  "valence-osmo-liquid-pooler",
  "valence-outpost-osmo-liquid-pooler",
+ "valence-remote-chain-splitter",
  "valence-single-party-pol-holder",
  "valence-stride-liquid-staker",
  "valence-two-party-pol-holder",

--- a/local-interchaintest/Cargo.toml
+++ b/local-interchaintest/Cargo.toml
@@ -30,6 +30,7 @@ valence-osmo-liquid-pooler = { workspace = true }
 valence-outpost-osmo-liquid-pooler = { workspace = true }
 valence-stride-liquid-staker = { workspace = true }
 valence-ibc-forwarder = { workspace = true }
+valence-remote-chain-splitter = { workspace = true }
 
 covenant-utils = { workspace = true }
 cw20 = { workspace = true }

--- a/local-interchaintest/src/main.rs
+++ b/local-interchaintest/src/main.rs
@@ -3,6 +3,7 @@
 use std::error::Error;
 
 use local_ictest_e2e::tests::{
+    remote_chain_splitter::remote_chain_splitter::test_remote_chain_splitter,
     single_party_pol::single_party_pol_stride::test_single_party_pol_stride,
     swap::token_swap::test_token_swap,
     two_party_pol::{
@@ -45,6 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     test_two_party_pol_osmo(&mut test_ctx);
     test_two_party_pol_native(&mut test_ctx);
     test_two_party_pol(&mut test_ctx);
+    test_remote_chain_splitter(&mut test_ctx);
 
     Ok(())
 }

--- a/local-interchaintest/src/tests/mod.rs
+++ b/local-interchaintest/src/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod remote_chain_splitter;
 pub mod single_party_pol;
 pub mod swap;
 pub mod two_party_pol;

--- a/local-interchaintest/src/tests/remote_chain_splitter/mod.rs
+++ b/local-interchaintest/src/tests/remote_chain_splitter/mod.rs
@@ -1,0 +1,1 @@
+pub mod remote_chain_splitter;

--- a/local-interchaintest/src/tests/remote_chain_splitter/remote_chain_splitter.rs
+++ b/local-interchaintest/src/tests/remote_chain_splitter/remote_chain_splitter.rs
@@ -1,0 +1,307 @@
+use crate::helpers::constants::{
+    ACC1_ADDRESS_NEUTRON, ACC2_ADDRESS_NEUTRON, ASTROPORT_PATH, LOCAL_CODE_ID_CACHE_PATH,
+    VALENCE_PATH,
+};
+use cosmwasm_std::{Decimal, Uint128, Uint64};
+use covenant_utils::{op_mode::ContractOperationModeConfig, split::SplitConfig};
+use localic_std::{errors::LocalError, modules::cosmwasm::CosmWasm};
+use localic_utils::{
+    utils::test_context::TestContext, DEFAULT_KEY, GAIA_CHAIN_NAME, NEUTRON_CHAIN_ID,
+    NEUTRON_CHAIN_NAME,
+};
+use serde_json::Value;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
+use valence_covenant_single_party_pol::msg::DEFAULT_TIMEOUT;
+
+use log::info;
+
+struct ContractInfo {
+    code_id: u64,
+    contract_addr: String,
+}
+
+/// How long we will wait until the ICA must have been created, or timed out
+const ICA_TIMEOUT: Duration = Duration::from_secs(30);
+
+macro_rules! with_poll_timeout {
+    ($body:block) => {
+        let start = Instant::now();
+
+        while Instant::now().duration_since(start) < ICA_TIMEOUT {
+            $body
+        }
+    };
+}
+
+/// Tests that the remote chain splitter correctly handles
+/// - Normal case
+/// - Timeouts (does not advance to ica_created)
+/// - Timeout recovery (advances after on 2nd tick after a packet timeout)
+pub fn test_remote_chain_splitter(test_ctx: &mut TestContext) -> Result<(), LocalError> {
+    info!("Starting remote chain splitter tests...");
+
+    upload_contracts(test_ctx)?;
+
+    // See above: 3 tests, each with a different splitter
+    let splitters = (
+        make_remote_chain_splitter(test_ctx)?,
+        make_remote_chain_splitter(test_ctx)?,
+        make_remote_chain_splitter(test_ctx)?,
+    );
+    fund_remote_chain_splitter(test_ctx, &splitters.0)?;
+    fund_remote_chain_splitter(test_ctx, &splitters.1)?;
+    fund_remote_chain_splitter(test_ctx, &splitters.2)?;
+
+    // Separate tests: ensure that the splitter can handle the happy case
+    // and a timeout (independently)
+    test_remote_chain_splitter_ok(test_ctx, &splitters.0)?;
+    test_remote_chain_splitter_timeout(test_ctx, &splitters.1)?;
+
+    // Combined test: runs test_timeout and test_ok in sequence with the same splitter
+    // to ensure that the splitter can recover from a timeout
+    test_remote_chain_splitter_timeout_recover(test_ctx, &splitters.2)?;
+
+    info!("Finished remote chain splitter tests!");
+
+    Ok(())
+}
+
+fn start_relayer(test_ctx: &mut TestContext) {
+    let neutron = test_ctx.get_chain(NEUTRON_CHAIN_NAME);
+
+    reqwest::blocking::Client::default()
+        .post(&neutron.rb.api)
+        .json(&serde_json::json!({ "chain_id": NEUTRON_CHAIN_ID, "action": "start-relayer"}))
+        .send()
+        .unwrap();
+}
+
+fn stop_relayer(test_ctx: &mut TestContext) {
+    let neutron = test_ctx.get_chain(NEUTRON_CHAIN_NAME);
+
+    reqwest::blocking::Client::default()
+        .post(&neutron.rb.api)
+        .json(&serde_json::json!({ "chain_id": NEUTRON_CHAIN_ID, "action": "stop-relayer"}))
+        .send()
+        .unwrap();
+}
+
+fn upload_contracts(test_ctx: &mut TestContext) -> Result<(), LocalError> {
+    let mut uploader = test_ctx.build_tx_upload_contracts();
+
+    uploader
+        .send_with_local_cache(VALENCE_PATH, NEUTRON_CHAIN_NAME, LOCAL_CODE_ID_CACHE_PATH)
+        .unwrap();
+
+    uploader
+        .send_with_local_cache(ASTROPORT_PATH, NEUTRON_CHAIN_NAME, LOCAL_CODE_ID_CACHE_PATH)
+        .unwrap();
+
+    uploader.send().unwrap();
+
+    Ok(())
+}
+
+fn make_remote_chain_splitter(test_ctx: &mut TestContext) -> Result<ContractInfo, LocalError> {
+    let atom_denom = test_ctx.get_native_denom().src(GAIA_CHAIN_NAME).get();
+    let uatom_contribution_amount: u128 = 5_000_000_000;
+
+    let split_config: Vec<(String, SplitConfig)> = vec![(
+        atom_denom.clone(),
+        SplitConfig {
+            receivers: BTreeMap::from_iter(vec![
+                (ACC1_ADDRESS_NEUTRON.to_owned(), Decimal::percent(50)),
+                (ACC2_ADDRESS_NEUTRON.to_owned(), Decimal::percent(50)),
+            ]),
+        },
+    )];
+
+    let mut remote_chain_splitter = test_ctx
+        .get_contract("valence_remote_chain_splitter")
+        .unwrap();
+
+    remote_chain_splitter
+        .instantiate(
+            DEFAULT_KEY,
+            serde_json::to_string(&valence_remote_chain_splitter::msg::InstantiateMsg {
+                op_mode_cfg: ContractOperationModeConfig::Permissionless,
+                remote_chain_channel_id: test_ctx
+                    .get_transfer_channels()
+                    .src(NEUTRON_CHAIN_NAME)
+                    .dest(GAIA_CHAIN_NAME)
+                    .get(),
+                remote_chain_connection_id: test_ctx
+                    .get_connections()
+                    .src(NEUTRON_CHAIN_NAME)
+                    .dest(GAIA_CHAIN_NAME)
+                    .get(),
+                denom: atom_denom.clone(),
+                amount: Uint128::from(uatom_contribution_amount),
+                splits: BTreeMap::from_iter(split_config),
+                ica_timeout: Uint64::new(DEFAULT_TIMEOUT),
+                ibc_transfer_timeout: Uint64::new(DEFAULT_TIMEOUT),
+                fallback_address: None,
+            })
+            .unwrap()
+            .as_str(),
+            "valence_remote_chain_splitter",
+            None,
+            "",
+        )
+        .unwrap();
+
+    Ok(ContractInfo {
+        contract_addr: remote_chain_splitter.contract_addr.unwrap(),
+        code_id: remote_chain_splitter.code_id.unwrap(),
+    })
+}
+
+fn fund_remote_chain_splitter(
+    test_ctx: &mut TestContext,
+    remote_chain_splitter: &ContractInfo,
+) -> Result<(), LocalError> {
+    let neutron = test_ctx.get_chain(NEUTRON_CHAIN_NAME);
+
+    neutron
+        .rb
+        .tx(
+            &format!(
+                "tx bank send acc0 {} 1000000untrn",
+                &remote_chain_splitter.contract_addr
+            ),
+            true,
+        )
+        .unwrap();
+
+    Ok(())
+}
+
+/// Tests that the splitter does not advance when there is no relayer available.
+/// Leaves the relayer intact after its execution.
+fn test_remote_chain_splitter_timeout(
+    test_ctx: &mut TestContext,
+    remote_chain_splitter: &ContractInfo,
+) -> Result<(), LocalError> {
+    // Stop the relayer
+    stop_relayer(test_ctx);
+
+    let neutron = test_ctx.get_chain(NEUTRON_CHAIN_NAME);
+
+    let remote_chain_splitter_contract = CosmWasm::new_from_existing(
+        &neutron.rb,
+        None,
+        Some(remote_chain_splitter.code_id),
+        Some(remote_chain_splitter.contract_addr.clone()),
+    );
+
+    // Kill the relayer and advance the splitter.
+    // This should trigger SudoMsg::Timeout, which returns the state to instantiated
+
+    // Continuously tick the splitter until the state advances to timed out (after we expect the timeout)
+    with_poll_timeout! {
+        {
+            remote_chain_splitter_contract
+                .execute(
+                    DEFAULT_KEY,
+                    serde_json::to_string(&valence_remote_chain_splitter::msg::ExecuteMsg::Tick {})
+                        .unwrap()
+                        .as_str(),
+                    "--gas 42069420",
+                )
+                .unwrap();
+        }
+    }
+
+    assert!(
+        remote_chain_splitter_contract
+            .query(
+                &serde_json::to_string(
+                    &valence_remote_chain_splitter::msg::QueryMsg::ContractState {}
+                )
+                .unwrap()
+            )
+            .get("data")
+            == Some(&Value::String("instantiated".to_owned()))
+    );
+
+    start_relayer(test_ctx);
+
+    Ok(())
+}
+
+/// Tests that the splitter advances after 2nd tick after a packet timeout.
+fn test_remote_chain_splitter_timeout_recover(
+    test_ctx: &mut TestContext,
+    remote_chain_splitter: &ContractInfo,
+) -> Result<(), LocalError> {
+    // Stop the relayer and ensure the splitter does not advance beyond instantiated
+    stop_relayer(test_ctx);
+
+    test_remote_chain_splitter_timeout(test_ctx, remote_chain_splitter)?;
+
+    // Ensure that the splitter recovers after the relayer is started again
+    start_relayer(test_ctx);
+
+    test_remote_chain_splitter_ok(test_ctx, remote_chain_splitter)?;
+
+    Ok(())
+}
+
+fn test_remote_chain_splitter_ok(
+    test_ctx: &mut TestContext,
+    remote_chain_splitter: &ContractInfo,
+) -> Result<(), LocalError> {
+    let neutron = test_ctx.get_chain(NEUTRON_CHAIN_NAME);
+
+    // Advance the splitter.
+    // This should trigger SudoMsg::OpenAck, which will set the ContractState to IcaCreated
+
+    // The state should be IcaCreated
+    let remote_chain_splitter_contract = CosmWasm::new_from_existing(
+        &neutron.rb,
+        None,
+        Some(remote_chain_splitter.code_id),
+        Some(remote_chain_splitter.contract_addr.clone()),
+    );
+
+    with_poll_timeout! {
+        {
+             remote_chain_splitter_contract
+                .execute(
+                    DEFAULT_KEY,
+                    serde_json::to_string(&valence_remote_chain_splitter::msg::ExecuteMsg::Tick {})
+                        .unwrap()
+                        .as_str(),
+                    "--gas 42069420",
+                )
+                .unwrap();
+
+            if remote_chain_splitter_contract
+                .query(
+                    &serde_json::to_string(&valence_remote_chain_splitter::msg::QueryMsg::ContractState {})
+                        .unwrap(),
+                )
+                .get("data") == Some(&Value::String("ica_created".to_owned()))
+            {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(
+        remote_chain_splitter_contract
+            .query(
+                &serde_json::to_string(
+                    &valence_remote_chain_splitter::msg::QueryMsg::ContractState {}
+                )
+                .unwrap()
+            )
+            .get("data"),
+        Some(&Value::String("ica_created".to_owned()))
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #235 . This PR implements relayer edge case tests in local-interchain for the remote chain splitter. These tests include:

- Happy path test: ensure the remote chain splitter creates an ICA when the relayer is up
- Timeout handling test: ensure the remote chain splitter does not advance when the relayer is down (causing a packet timeout)
- Recovery test: ensure the remote chain splitter can continue after a timed out packet to create the ICA when the relayer is restored

## Failing Tests

Some local-ic tests are not currently working (namely the two party osmo pol test). However, all of the remote chain splitter tests are working. Fixing the two party osmo pol test is not within the scope of this PR, so I did not fix them.

## Overview on Changes / Additions

* `local-interchaintest/Cargo.toml` - Added the remote chain splitter as a dependency to local-ic so that it can be tested
* `Cargo.lock` - See above about `Cargo.toml`
* `local-interchaintest/src/main.rs` - Added the remote chain splitter tests as tests run by local-ictest-e2e
* `local-interchaintest/src/tests/mod.rs`, `local-interchaintest/src/tests/remote_chain_splitter/mod.rs` - Self explanatory
* `local-interchaintest/src/tests/remote_chain_splitter/remote_chain_splitter.rs` - See above on the 3 tests I added. *Of note:* two functions in this file, `start_relayer` and `stop_relayer` may be useful in other local-ic relayer tests, so moving them to a utils file could be prudent to prevent test dependencies across tests.

### Macro Usage

There is a very short macro in `remote_chain_splitter.rs`. I can remove it if necessary. The macro just consolidates some redundant timeout checking logic in a way that allows breaking from the timeout check on successful ICA creation, which would be slightly more convoluted with a function. IMO, it's short and relatively useful, but not necessary, so it can be removed if desired.